### PR TITLE
feat: reset cache once per week.

### DIFF
--- a/.github/workflows/measure-contributors.yml
+++ b/.github/workflows/measure-contributors.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 0 * * *'  # Daily at midnight
-    - cron: '0 0 * * 1'  # Weekly on Monday (clears cache)
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       clear_cache:
@@ -36,7 +35,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Check if cache should be cleared
+      - name: Set clear_cache flags on Mondays or if requested
         id: check_cache
         run: |
           if [ "$(date +%u)" = "1" ] || [ "${{ github.event.inputs.clear_cache }}" = "true" ]; then


### PR DESCRIPTION
## Description

I have noticed that number of contributors on my fork was different from what we see in upstream:
 - https://mitsudome-r.github.io/autoware-contributor-metrics/
 - https://autowarefoundation.github.io/autoware-contributor-metrics/

<img width="1310" height="679" alt="image" src="https://github.com/user-attachments/assets/6066605c-6fad-4dee-9fa4-12361ec4965a" />
<img width="1324" height="687" alt="image" src="https://github.com/user-attachments/assets/b6604e18-5497-407f-a5f7-632ba35b6b1d" />

This happens because we also count people who made comments to issues/PRs/Discussions that were created in the past. When we use --use-cache option for scripts/get_contributors.py scripts, we only retrieve information from newly created issues so cannot count those people who commented for older threads.

As a compromise, I added a feature to skip restoring of cache in the workflow once a week so that we will regenerate cache from scratch on weekly basis. I also added an argument to workflow dispatch in just case. 