### PR TITLE
feat: add External Visibility section (arXiv mentions + Google Trends)

### DIFF
--- a/.github/workflows/measure-contributors.yml
+++ b/.github/workflows/measure-contributors.yml
@@ -60,6 +60,9 @@ jobs:
           python scripts/get_stargazers.py --token ${{ secrets.ACCESS_TOKEN }} --use-cache
           python scripts/get_commits.py --token ${{ secrets.ACCESS_TOKEN }} --use-cache
           python scripts/get_apt_downloads.py --use-cache
+          python scripts/get_arxiv_mentions.py --use-cache
+          python scripts/get_arxiv_citations.py --use-cache
+          python scripts/get_google_trends.py || echo "Google Trends fetch failed; keeping previous data"
           python scripts/calculate_contributor_history.py
           python scripts/calculate_stargazers_history.py
           python scripts/calculate_commits_history.py
@@ -71,6 +74,9 @@ jobs:
           cp results/activity_history.json public/
           cp results/rankings.json public/
           cp results/apt_downloads.json public/
+          cp results/arxiv_mentions_history.json public/
+          cp results/arxiv_citations_history.json public/
+          [ -f results/google_trends_history.json ] && cp results/google_trends_history.json public/ || true
 
       - name: Save cache
         uses: actions/cache/save@v4

--- a/.github/workflows/measure-contributors.yml
+++ b/.github/workflows/measure-contributors.yml
@@ -62,7 +62,7 @@ jobs:
           python scripts/get_apt_downloads.py --use-cache
           python scripts/get_arxiv_mentions.py --use-cache
           python scripts/get_arxiv_citations.py --use-cache
-          python scripts/get_google_trends.py || echo "Google Trends fetch failed; keeping previous data"
+          python scripts/get_google_trends.py
           python scripts/calculate_contributor_history.py
           python scripts/calculate_stargazers_history.py
           python scripts/calculate_commits_history.py
@@ -76,7 +76,7 @@ jobs:
           cp results/apt_downloads.json public/
           cp results/arxiv_mentions_history.json public/
           cp results/arxiv_citations_history.json public/
-          [ -f results/google_trends_history.json ] && cp results/google_trends_history.json public/ || true
+          cp results/google_trends_history.json public/
 
       - name: Save cache
         uses: actions/cache/save@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This repository tracks and visualizes contributor and stargazer metrics for Autoware Foundation repositories. It generates JSON data files from GitHub's GraphQL API and displays interactive charts on a GitHub Pages site showing:
 - GitHub star growth over time across repositories
 - Contributor growth (code contributors, community contributors, and total)
+- External visibility: arXiv mentions, citation counts (OpenAlex), and Google Trends search interest
 
 Live site: https://autowarefoundation.github.io/autoware-contributor-metrics/index.html
 
@@ -44,8 +45,17 @@ python scripts/calculate_activity_history.py
 # 8. Calculate contributor rankings
 python scripts/calculate_rankings.py
 
-# 9. Copy results to public folder
-cp results/contributors_history.json results/stars_history.json results/commits_history.json results/activity_history.json results/rankings.json public/
+# 9. Fetch arXiv papers mentioning Autoware (no token required)
+python scripts/get_arxiv_mentions.py
+
+# 10. Fetch citation counts from OpenAlex for the arXiv papers (no token required)
+python scripts/get_arxiv_citations.py
+
+# 11. Fetch Google Trends search interest (no token required; may fail intermittently)
+python scripts/get_google_trends.py
+
+# 12. Copy results to public folder
+cp results/contributors_history.json results/stars_history.json results/commits_history.json results/activity_history.json results/rankings.json results/arxiv_mentions_history.json results/arxiv_citations_history.json results/google_trends_history.json public/
 ```
 
 Alternatively, use the `GITHUB_TOKEN` environment variable instead of `--token`:
@@ -59,6 +69,8 @@ For incremental updates (faster, fetches only new data since last run):
 python scripts/get_contributors.py --use-cache
 python scripts/get_stargazers.py --use-cache
 python scripts/get_commits.py --use-cache
+python scripts/get_arxiv_mentions.py --use-cache
+python scripts/get_arxiv_citations.py --use-cache
 ```
 
 ### Installing dependencies
@@ -67,7 +79,7 @@ python scripts/get_commits.py --use-cache
 pip install -r requirements.txt
 ```
 
-The only external dependency is `requests>=2.31.0`.
+External dependencies: `requests>=2.31.0`, `pytrends>=4.9.2` (for Google Trends — pulls in `pandas` and `lxml` transitively).
 
 ### Viewing the dashboard locally
 
@@ -78,7 +90,7 @@ python -m http.server 8000
 # Visit http://localhost:8000/index.html
 ```
 
-The page expects `contributors_history.json`, `stars_history.json`, `commits_history.json`, `activity_history.json`, `rankings.json`, and `repositories.json` to be in the `public/` directory.
+The page expects `contributors_history.json`, `stars_history.json`, `commits_history.json`, `activity_history.json`, `rankings.json`, `repositories.json`, `arxiv_mentions_history.json`, `arxiv_citations_history.json`, and `google_trends_history.json` to be in the `public/` directory.
 
 ## Architecture
 
@@ -97,9 +109,38 @@ GitHub GraphQL API
 6. calculate_commits_history.py → results/commits_history.json
 7. calculate_activity_history.py → results/activity_history.json
 8. calculate_rankings.py → results/rankings.json
+9. get_arxiv_mentions.py → cache/raw_arxiv_data/papers.json + results/arxiv_mentions_history.json
+10. get_arxiv_citations.py → cache/raw_arxiv_data/openalex_works.json + results/arxiv_citations_history.json
+11. get_google_trends.py → results/google_trends_history.json
     ↓
 Copy to public/ → Visualized in index.html
 ```
+
+### External Visibility Pipeline
+
+Three additional fetchers do their own aggregation in-script (no separate
+calculate step):
+
+- **`get_arxiv_mentions.py`** — queries the arXiv Atom API for papers
+  containing "autoware" (`all:autoware`). Caches raw entries by arXiv ID and
+  produces a per-month time series of new submissions and cumulative count.
+  Pagination uses `submittedDate ascending` for stable ordering; the polite
+  delay between requests is 3.5s.
+
+- **`get_arxiv_citations.py`** — for each cached arXiv paper, looks up the
+  OpenAlex work via the arXiv DOI form (`10.48550/arXiv.<id>`). Stores the
+  slim record (cited_by_count, counts_by_year, publication_year) and aggregates
+  yearly citation totals across all papers. Set `OPENALEX_MAILTO` env var to
+  your email to use the OpenAlex polite pool (defaults to repo maintainer's
+  address). Yearly granularity is the finest OpenAlex offers; monthly trend is
+  not available from OpenAlex. Use `--use-cache` to only fetch new papers.
+
+- **`get_google_trends.py`** — queries Google Trends via `pytrends` for
+  worldwide monthly relative interest in the keyword `Autoware` since 2018.
+  Values are 0-100 normalized against the peak month, *not* absolute search
+  volume. Google may rate-limit or block requests intermittently; the workflow
+  swallows failures (`|| echo`) so the rest of the pipeline keeps running and
+  the previously-published JSON remains served.
 
 ### Key Components
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ calculate step):
 
 - **`get_arxiv_mentions.py`** — queries the arXiv Atom API for papers
   containing "autoware" (`all:autoware`). Caches raw entries by arXiv ID and
-  produces a per-month time series of new submissions and cumulative count.
+  produces a yearly time series of new submissions and cumulative count.
   Pagination uses `submittedDate ascending` for stable ordering; the polite
   delay between requests is 3.5s.
 
@@ -138,9 +138,11 @@ calculate step):
 - **`get_google_trends.py`** — queries Google Trends via `pytrends` for
   worldwide monthly relative interest in the keyword `Autoware` since 2018.
   Values are 0-100 normalized against the peak month, *not* absolute search
-  volume. Google may rate-limit or block requests intermittently; the workflow
-  swallows failures (`|| echo`) so the rest of the pipeline keeps running and
-  the previously-published JSON remains served.
+  volume. Google rate-limits pytrends aggressively; on fetch failure the
+  script falls back to the most recent successful payload cached at
+  `cache/raw_google_trends_data/google_trends_history.json`, so the deployed
+  Pages artifact keeps showing the previous snapshot instead of dropping the
+  file. The workflow's `actions/cache` keys persist that cache between runs.
 
 ### Key Components
 

--- a/public/index.html
+++ b/public/index.html
@@ -68,6 +68,7 @@
         <div class="nav-inner">
           <a href="#stars" class="nav-link active" data-section="stars">Stars</a>
           <a href="#downloads" class="nav-link" data-section="downloads">Downloads</a>
+          <a href="#visibility" class="nav-link" data-section="visibility">Visibility</a>
           <a href="#commits" class="nav-link" data-section="commits">Commits</a>
           <a href="#contributors" class="nav-link" data-section="contributors">Contributors</a>
           <a href="#rankings" class="nav-link" data-section="rankings">Rankings</a>
@@ -102,6 +103,23 @@
           <div class="skeleton skeleton-chart"></div>
         </div>
         <div id="downloads-ranking-chart" class="chart-wrapper">
+          <div class="skeleton skeleton-chart"></div>
+        </div>
+      </section>
+
+      <!-- External Visibility Section -->
+      <section id="visibility" class="dashboard-section" data-section>
+        <h2 class="section-heading">External Visibility</h2>
+        <div id="visibility-stats" class="stats-grid">
+          <div class="skeleton skeleton-card"></div>
+          <div class="skeleton skeleton-card"></div>
+          <div class="skeleton skeleton-card"></div>
+          <div class="skeleton skeleton-card"></div>
+        </div>
+        <div id="google-trends-chart" class="chart-wrapper">
+          <div class="skeleton skeleton-chart"></div>
+        </div>
+        <div id="arxiv-mentions-chart" class="chart-wrapper">
           <div class="skeleton skeleton-chart"></div>
         </div>
       </section>

--- a/public/main.js
+++ b/public/main.js
@@ -75,6 +75,7 @@ const COLORS = {
   contributors: ['#00D9FF', '#FF6B6B', '#4ECDC4'],
   downloads: ['#00D9FF', '#FF6B6B', '#4ECDC4', '#FFE66D'],
   commits: ['#00D9FF', '#FF6B6B', '#4ECDC4'],
+  visibility: ['#00D9FF', '#FF6B6B', '#FFE66D'],
 };
 
 const RANKING_CATEGORIES = [
@@ -564,6 +565,141 @@ function renderCommitsStats(commitsJson, activityJson) {
 
 
 // =============================================================================
+// External Visibility Section
+// =============================================================================
+
+function monthToDate(monthStr) {
+  // "YYYY-MM" -> Date at first of month
+  const [y, m] = monthStr.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, 1));
+}
+
+function renderArxivMentionsChart(arxivJson) {
+  const chartEl = document.querySelector('#arxiv-mentions-chart');
+  chartEl.innerHTML = '';
+  const yearly = (arxivJson && arxivJson.yearly) || [];
+
+  const series = [
+    {
+      name: 'New papers / year',
+      type: 'column',
+      data: yearly.map(y => y.count),
+    },
+    {
+      name: 'Cumulative papers',
+      type: 'line',
+      data: yearly.map(y => y.cumulative),
+    },
+  ];
+  const categories = yearly.map(y => String(y.year));
+
+  const options = {
+    series,
+    chart: {
+      type: 'line',
+      height: getChartHeight(400),
+      toolbar: { show: true },
+      background: 'transparent',
+      stacked: false,
+    },
+    title: {
+      text: 'arXiv Papers Mentioning "Autoware" (Yearly)',
+      align: 'left',
+      style: { fontSize: '16px', fontFamily: 'Outfit, sans-serif', fontWeight: 600 },
+    },
+    stroke: { width: [0, 3], curve: 'smooth' },
+    plotOptions: { bar: { borderRadius: 3, columnWidth: '55%' } },
+    dataLabels: { enabled: false },
+    xaxis: { categories },
+    yaxis: [
+      {
+        seriesName: 'New papers / year',
+        min: 0,
+        title: { text: 'New papers' },
+        labels: { formatter: formatNumber },
+      },
+      {
+        seriesName: 'Cumulative papers',
+        opposite: true,
+        min: 0,
+        title: { text: 'Cumulative' },
+        labels: { formatter: formatNumber },
+      },
+    ],
+    tooltip: { theme: 'dark', shared: true, y: { formatter: formatNumber } },
+    colors: COLORS.visibility,
+    legend: {
+      position: 'bottom', horizontalAlign: 'center',
+      fontSize: '12px', fontFamily: 'Outfit, sans-serif',
+      markers: { width: 10, height: 10, radius: 3 },
+    },
+    grid: { row: { opacity: 0 } },
+  };
+  new ApexCharts(chartEl, options).render();
+}
+
+function renderGoogleTrendsChart(trendsJson) {
+  const chartEl = document.querySelector('#google-trends-chart');
+  chartEl.innerHTML = '';
+  const monthly = (trendsJson && trendsJson.monthly) || [];
+
+  const series = [{
+    name: 'Search interest (0-100)',
+    data: monthly.map(m => [monthToDate(m.month).getTime(), m.interest]),
+  }];
+
+  const options = {
+    series,
+    chart: {
+      type: 'area',
+      height: getChartHeight(380),
+      toolbar: { show: true },
+      background: 'transparent',
+      zoom: { enabled: true },
+    },
+    title: {
+      text: 'Google Trends: "Autoware" Worldwide Search Interest (Monthly)',
+      align: 'left',
+      style: { fontSize: '16px', fontFamily: 'Outfit, sans-serif', fontWeight: 600 },
+    },
+    subtitle: {
+      text: 'Relative interest (100 = peak month). Not absolute search volume.',
+      align: 'left',
+      style: { fontSize: '12px', fontFamily: 'Outfit, sans-serif', color: 'var(--text-muted)' },
+    },
+    stroke: { width: 2, curve: 'smooth' },
+    fill: { type: 'gradient', gradient: { shadeIntensity: 1, opacityFrom: 0.4, opacityTo: 0.05 } },
+    dataLabels: { enabled: false },
+    xaxis: { type: 'datetime' },
+    yaxis: { min: 0, max: 100, title: { text: 'Interest' } },
+    tooltip: { theme: 'dark', x: { format: 'MMM yyyy' } },
+    colors: [COLORS.visibility[0]],
+    grid: { row: { opacity: 0 } },
+  };
+  new ApexCharts(chartEl, options).render();
+}
+
+function renderVisibilityStats(arxivJson, citationsJson, trendsJson) {
+  const totalPapers = (arxivJson && arxivJson.total_papers) || 0;
+  const latestPaperYear = arxivJson?.yearly?.length
+    ? arxivJson.yearly[arxivJson.yearly.length - 1]
+    : null;
+  const totalCitations = (citationsJson && citationsJson.total_citations) || 0;
+  const latestTrend = trendsJson?.monthly?.length
+    ? trendsJson.monthly[trendsJson.monthly.length - 1]
+    : null;
+
+  const cards = [
+    createMetricCard('Search Interest (Latest)', latestTrend?.interest || 0, 'yellow', latestTrend?.month || 'N/A'),
+    createMetricCard('arXiv Papers (Total)', totalPapers, 'cyan', 'Mentioning "Autoware"'),
+    createMetricCard('New Papers (Latest Year)', latestPaperYear?.count || 0, 'cyan', latestPaperYear?.year ? String(latestPaperYear.year) : 'N/A'),
+    createMetricCard('Total Citations', totalCitations, 'coral', 'OpenAlex, all years'),
+  ];
+  renderMetricCards('visibility-stats', cards);
+}
+
+
+// =============================================================================
 // Rankings
 // =============================================================================
 
@@ -765,13 +901,26 @@ try {
 } catch { /* REPOSITORIES stays [] */ }
 
 // 2. Load data files in parallel
-const [starsResult, contributorsResult, rankingsResult, downloadsResult, commitsResult, activityResult] = await Promise.allSettled([
+const [
+  starsResult,
+  contributorsResult,
+  rankingsResult,
+  downloadsResult,
+  commitsResult,
+  activityResult,
+  arxivMentionsResult,
+  arxivCitationsResult,
+  googleTrendsResult,
+] = await Promise.allSettled([
   fetch('stars_history.json').then(r => r.json()),
   fetch('contributors_history.json').then(r => r.json()),
   fetch('rankings.json').then(r => r.json()),
   fetch('apt_downloads.json').then(r => r.json()),
   fetch('commits_history.json').then(r => r.json()),
   fetch('activity_history.json').then(r => r.json()),
+  fetch('arxiv_mentions_history.json').then(r => r.json()),
+  fetch('arxiv_citations_history.json').then(r => r.json()),
+  fetch('google_trends_history.json').then(r => r.json()),
 ]);
 
 // 3. Render each independently (error per section)
@@ -804,6 +953,22 @@ if (commitsResult.status === 'fulfilled') {
 } else {
   showError('#commits-chart', 'Commit history data not available');
 }
+
+const arxivMentions = arxivMentionsResult.status === 'fulfilled' ? arxivMentionsResult.value : null;
+const arxivCitations = arxivCitationsResult.status === 'fulfilled' ? arxivCitationsResult.value : null;
+const googleTrends = googleTrendsResult.status === 'fulfilled' ? googleTrendsResult.value : null;
+
+if (arxivMentions) {
+  renderArxivMentionsChart(arxivMentions);
+} else {
+  showError('#arxiv-mentions-chart', 'arXiv mentions data not available');
+}
+if (googleTrends) {
+  renderGoogleTrendsChart(googleTrends);
+} else {
+  showError('#google-trends-chart', 'Google Trends data not available');
+}
+renderVisibilityStats(arxivMentions, arxivCitations, googleTrends);
 
 if (rankingsResult.status === 'fulfilled') {
   rankingsData = rankingsResult.value;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.31.0
+pytrends>=4.9.2

--- a/scripts/get_arxiv_citations.py
+++ b/scripts/get_arxiv_citations.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fetch citation counts from OpenAlex for Autoware-mentioning arXiv papers.
+
+For each paper in cache/raw_arxiv_data/papers.json, queries OpenAlex via
+the arXiv DOI form (10.48550/arXiv.<id>) and stores the work record. Then
+aggregates counts_by_year across all papers into a yearly time series.
+"""
+
+import argparse
+import datetime
+import os
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+
+from utils import write_json_output, load_json_file
+
+PAPERS_CACHE = "cache/raw_arxiv_data/papers.json"
+WORKS_CACHE = "cache/raw_arxiv_data/openalex_works.json"
+OUTPUT_FILE = "results/arxiv_citations_history.json"
+
+OPENALEX_DOI_URL = "https://api.openalex.org/works/doi:10.48550/arXiv.{arxiv_id}"
+REQUEST_DELAY_SEC = 0.15  # ~7 req/sec, well under polite-pool limit
+MAX_RETRIES = 4
+START_YEAR = 2018
+
+
+def build_session() -> requests.Session:
+    """Build a requests session with the OpenAlex polite-pool User-Agent."""
+    s = requests.Session()
+    mailto = os.environ.get("OPENALEX_MAILTO", "yutaka.kondo@youtalk.jp")
+    s.headers["User-Agent"] = f"autoware-contributor-metrics (mailto:{mailto})"
+    return s
+
+
+def fetch_work(session: requests.Session, arxiv_id: str) -> dict | None:
+    """Fetch one OpenAlex work for an arXiv ID. Returns None on 404 / hard error."""
+    url = OPENALEX_DOI_URL.format(arxiv_id=arxiv_id)
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = session.get(url, timeout=30)
+            if resp.status_code == 404:
+                return None
+            if resp.status_code == 429:
+                wait = (attempt + 1) * 5
+                print(f"  Rate limited. Waiting {wait}s...")
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        except requests.exceptions.RequestException as e:
+            wait = 2 ** attempt
+            print(f"  Error for {arxiv_id} (attempt {attempt + 1}): {e}. Retrying in {wait}s...")
+            time.sleep(wait)
+    return None
+
+
+def slim_work(work: dict) -> dict:
+    """Keep only the fields we need from the OpenAlex work record."""
+    return {
+        "openalex_id": work.get("id"),
+        "title": work.get("title"),
+        "cited_by_count": work.get("cited_by_count", 0),
+        "publication_year": work.get("publication_year"),
+        "counts_by_year": work.get("counts_by_year", []),
+    }
+
+
+def aggregate_yearly(works_by_id: dict[str, dict]) -> list[dict]:
+    """Aggregate counts_by_year across all works into a sorted yearly series."""
+    totals: dict[int, int] = defaultdict(int)
+    for work in works_by_id.values():
+        for entry in work.get("counts_by_year", []) or []:
+            year = entry.get("year")
+            count = entry.get("cited_by_count", 0)
+            if isinstance(year, int) and year >= START_YEAR:
+                totals[year] += count
+
+    if not totals:
+        return []
+
+    end_year = max(totals.keys())
+    out = []
+    cumulative = 0
+    for year in range(START_YEAR, end_year + 1):
+        c = totals.get(year, 0)
+        cumulative += c
+        out.append({"year": year, "citations": c, "cumulative": cumulative})
+    return out
+
+
+def top_cited(works_by_id: dict[str, dict], papers_by_id: dict[str, dict], n: int = 10) -> list[dict]:
+    """Return top-N cited papers with arXiv IDs and titles."""
+    rows = []
+    for arxiv_id, work in works_by_id.items():
+        rows.append({
+            "arxiv_id": arxiv_id,
+            "title": papers_by_id.get(arxiv_id, {}).get("title") or work.get("title"),
+            "cited_by_count": work.get("cited_by_count", 0),
+            "publication_year": work.get("publication_year"),
+        })
+    rows.sort(key=lambda r: r["cited_by_count"], reverse=True)
+    return rows[:n]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch citation counts from OpenAlex")
+    parser.add_argument(
+        "--use-cache", action="store_true",
+        help="Skip OpenAlex lookup for papers already cached",
+    )
+    parser.add_argument(
+        "--refresh-all", action="store_true",
+        help="Re-fetch all papers from OpenAlex even if cached",
+    )
+    args = parser.parse_args()
+
+    papers = load_json_file(PAPERS_CACHE)
+    if not papers:
+        raise SystemExit(f"No papers in {PAPERS_CACHE}. Run get_arxiv_mentions.py first.")
+    papers_by_id = {p["arxiv_id"]: p for p in papers}
+    print(f"Loaded {len(papers)} papers")
+
+    cached = load_json_file(WORKS_CACHE) if not args.refresh_all else {}
+    if not isinstance(cached, dict):
+        cached = {}
+    print(f"Loaded {len(cached)} cached OpenAlex works")
+
+    session = build_session()
+    works_by_id: dict[str, dict] = dict(cached)
+    not_found: list[str] = []
+
+    to_fetch = [pid for pid in papers_by_id if pid not in works_by_id or not args.use_cache]
+    if args.use_cache and not args.refresh_all:
+        to_fetch = [pid for pid in papers_by_id if pid not in works_by_id]
+
+    print(f"Fetching {len(to_fetch)} works from OpenAlex...")
+    for i, arxiv_id in enumerate(to_fetch, 1):
+        if i % 10 == 0 or i == len(to_fetch):
+            print(f"  [{i}/{len(to_fetch)}] {arxiv_id}")
+        work = fetch_work(session, arxiv_id)
+        if work is None:
+            not_found.append(arxiv_id)
+            continue
+        works_by_id[arxiv_id] = slim_work(work)
+        time.sleep(REQUEST_DELAY_SEC)
+
+    write_json_output(works_by_id, WORKS_CACHE)
+    print(f"Cached {len(works_by_id)} OpenAlex works ({len(not_found)} not found)")
+
+    yearly = aggregate_yearly(works_by_id)
+    top = top_cited(works_by_id, papers_by_id, n=10)
+    total_citations = sum(w.get("cited_by_count", 0) for w in works_by_id.values())
+
+    output = {
+        "yearly": yearly,
+        "top_cited_papers": top,
+        "total_citations": total_citations,
+        "papers_with_data": len(works_by_id),
+        "papers_not_found": not_found,
+        "last_updated": datetime.date.today().strftime("%Y-%m-%d"),
+        "source": "OpenAlex (via arXiv DOI)",
+    }
+    write_json_output(output, OUTPUT_FILE)
+
+    print(f"\nDone! Generated {OUTPUT_FILE}")
+    print(f"Total citations across all Autoware-mentioning arXiv papers: {total_citations}")
+    if yearly:
+        latest = yearly[-1]
+        print(f"Latest year {latest['year']}: {latest['citations']} new, {latest['cumulative']} cumulative")
+    print(f"\nTop 5 cited papers:")
+    for row in top[:5]:
+        print(f"  {row['cited_by_count']:>4}  {row['arxiv_id']}  {(row['title'] or '')[:70]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_arxiv_citations.py
+++ b/scripts/get_arxiv_citations.py
@@ -11,7 +11,6 @@ import datetime
 import os
 import time
 from collections import defaultdict
-from pathlib import Path
 
 import requests
 

--- a/scripts/get_arxiv_mentions.py
+++ b/scripts/get_arxiv_mentions.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Fetch arXiv papers mentioning Autoware and aggregate monthly counts.
+"""Fetch arXiv papers mentioning Autoware and aggregate yearly counts.
 
 Queries the arXiv API for papers containing "autoware" in title, abstract,
-or full-text fields, caches the raw entries, and produces a monthly
-time-series of new submissions.
+or full-text fields, caches the raw entries, and produces a yearly
+time-series of new submissions plus a cumulative total.
 """
 
 import argparse

--- a/scripts/get_arxiv_mentions.py
+++ b/scripts/get_arxiv_mentions.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fetch arXiv papers mentioning Autoware and aggregate monthly counts.
+
+Queries the arXiv API for papers containing "autoware" in title, abstract,
+or full-text fields, caches the raw entries, and produces a monthly
+time-series of new submissions.
+"""
+
+import argparse
+import datetime
+import time
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+
+from utils import write_json_output, load_json_file
+
+ARXIV_API_URL = "http://export.arxiv.org/api/query"
+ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
+
+CACHE_FILE = "cache/raw_arxiv_data/papers.json"
+OUTPUT_FILE = "results/arxiv_mentions_history.json"
+
+SEARCH_QUERY = "all:autoware"
+PAGE_SIZE = 200
+REQUEST_DELAY_SEC = 3.5
+MAX_RETRIES = 5
+START_MONTH = "2018-01"
+
+
+def fetch_page(start: int, max_results: int) -> str:
+    """Fetch one page of results from arXiv API. Returns Atom XML text."""
+    params = {
+        "search_query": SEARCH_QUERY,
+        "start": start,
+        "max_results": max_results,
+        "sortBy": "submittedDate",
+        "sortOrder": "ascending",
+    }
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = requests.get(ARXIV_API_URL, params=params, timeout=60)
+            resp.raise_for_status()
+            return resp.text
+        except requests.exceptions.RequestException as e:
+            wait = 2 ** attempt * REQUEST_DELAY_SEC
+            print(f"  Error (attempt {attempt + 1}): {e}. Retrying in {wait:.1f}s...")
+            time.sleep(wait)
+    raise RuntimeError(f"Failed to fetch arXiv page at start={start} after {MAX_RETRIES} retries")
+
+
+def parse_entries(xml_text: str) -> list[dict]:
+    """Parse arXiv Atom XML and extract paper entries."""
+    root = ET.fromstring(xml_text)
+    entries = []
+    for entry in root.findall("atom:entry", ATOM_NS):
+        id_url = entry.findtext("atom:id", default="", namespaces=ATOM_NS)
+        title = (entry.findtext("atom:title", default="", namespaces=ATOM_NS) or "").strip()
+        published = entry.findtext("atom:published", default="", namespaces=ATOM_NS)
+        updated = entry.findtext("atom:updated", default="", namespaces=ATOM_NS)
+        summary = (entry.findtext("atom:summary", default="", namespaces=ATOM_NS) or "").strip()
+        authors = [
+            a.findtext("atom:name", default="", namespaces=ATOM_NS)
+            for a in entry.findall("atom:author", ATOM_NS)
+        ]
+        # arxiv_id like "2106.12345" extracted from "http://arxiv.org/abs/2106.12345v2"
+        arxiv_id = id_url.rsplit("/", 1)[-1].split("v")[0] if id_url else ""
+        if not arxiv_id or not published:
+            continue
+        entries.append({
+            "arxiv_id": arxiv_id,
+            "title": title,
+            "summary": summary,
+            "published": published,
+            "updated": updated,
+            "authors": authors,
+        })
+    return entries
+
+
+def fetch_all(known_ids: set[str]) -> list[dict]:
+    """Fetch all matching entries, skipping those already in known_ids when possible."""
+    all_entries: list[dict] = []
+    start = 0
+    while True:
+        print(f"Fetching arXiv start={start}...")
+        xml_text = fetch_page(start, PAGE_SIZE)
+        entries = parse_entries(xml_text)
+        if not entries:
+            print("  No more entries.")
+            break
+        new_count = sum(1 for e in entries if e["arxiv_id"] not in known_ids)
+        all_entries.extend(entries)
+        print(f"  Got {len(entries)} entries ({new_count} new)")
+        if len(entries) < PAGE_SIZE:
+            break
+        start += PAGE_SIZE
+        time.sleep(REQUEST_DELAY_SEC)
+    return all_entries
+
+
+def aggregate_yearly(papers: list[dict]) -> dict[int, int]:
+    """Count papers per year based on the published date."""
+    counts: dict[int, int] = defaultdict(int)
+    start_year = int(START_MONTH[:4])
+    for p in papers:
+        pub = p.get("published", "")
+        if len(pub) < 4:
+            continue
+        try:
+            year = int(pub[:4])
+        except ValueError:
+            continue
+        if year < start_year:
+            continue
+        counts[year] += 1
+    return dict(counts)
+
+
+def fill_missing_years(counts: dict[int, int], end_year: int) -> list[dict]:
+    """Return a sorted yearly list with zeros filled in for gaps."""
+    if not counts:
+        return []
+    start_year = int(START_MONTH[:4])
+    end = max(end_year, max(counts.keys()))
+    out = []
+    cumulative = 0
+    for year in range(start_year, end + 1):
+        c = counts.get(year, 0)
+        cumulative += c
+        out.append({"year": year, "count": c, "cumulative": cumulative})
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch arXiv papers mentioning Autoware")
+    parser.add_argument(
+        "--use-cache", action="store_true",
+        help="Reuse cached papers and only append new entries since last fetch",
+    )
+    args = parser.parse_args()
+
+    Path(CACHE_FILE).parent.mkdir(parents=True, exist_ok=True)
+
+    cached = load_json_file(CACHE_FILE) if args.use_cache else []
+    cached_by_id: dict[str, dict] = {p["arxiv_id"]: p for p in cached if isinstance(p, dict)}
+    known_ids = set(cached_by_id.keys())
+    print(f"Loaded {len(known_ids)} cached papers")
+
+    fetched = fetch_all(known_ids)
+    for e in fetched:
+        cached_by_id[e["arxiv_id"]] = e
+
+    papers = sorted(cached_by_id.values(), key=lambda x: x.get("published", ""))
+    write_json_output(papers, CACHE_FILE)
+    print(f"Cached {len(papers)} total papers")
+
+    today = datetime.date.today()
+    yearly_counts = aggregate_yearly(papers)
+    yearly_history = fill_missing_years(yearly_counts, today.year)
+
+    output = {
+        "yearly": yearly_history,
+        "total_papers": len(papers),
+        "last_updated": today.strftime("%Y-%m-%d"),
+        "query": SEARCH_QUERY,
+    }
+    write_json_output(output, OUTPUT_FILE)
+    print(f"\nDone! Generated {OUTPUT_FILE}")
+    print(f"Total papers mentioning Autoware: {len(papers)}")
+    if yearly_history:
+        latest = yearly_history[-1]
+        print(f"Latest year {latest['year']}: {latest['count']} new, {latest['cumulative']} cumulative")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_google_trends.py
+++ b/scripts/get_google_trends.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Fetch Google Trends interest-over-time for the "Autoware" keyword.
+
+Uses pytrends to query Google Trends for the worldwide monthly relative
+search interest for "Autoware". Values are normalized 0-100 against the
+peak month in the requested range, and represent relative search interest,
+not absolute search volume.
+"""
+
+import argparse
+import datetime
+import time
+from pathlib import Path
+
+from pytrends.request import TrendReq
+
+from utils import write_json_output
+
+OUTPUT_FILE = "results/google_trends_history.json"
+KEYWORD = "Autoware"
+START_DATE = "2018-01-01"
+GEO = ""  # worldwide
+HL = "en-US"
+TZ = 540  # JST
+MAX_RETRIES = 4
+
+
+def fetch_trends(end_date: str) -> list[dict]:
+    """Fetch monthly interest-over-time for the Autoware keyword.
+
+    Returns a list of {month, interest, is_partial} dicts.
+    """
+    timeframe = f"{START_DATE} {end_date}"
+    last_err: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            pytrends = TrendReq(hl=HL, tz=TZ, timeout=(10, 30))
+            pytrends.build_payload(kw_list=[KEYWORD], timeframe=timeframe, geo=GEO)
+            df = pytrends.interest_over_time()
+            if df.empty:
+                raise RuntimeError("Empty interest_over_time result")
+            rows = []
+            for ts, row in df.iterrows():
+                rows.append({
+                    "month": ts.strftime("%Y-%m"),
+                    "interest": int(row[KEYWORD]),
+                    "is_partial": bool(row.get("isPartial", False)),
+                })
+            return rows
+        except Exception as e:
+            wait = 2 ** attempt * 5
+            print(f"  Error (attempt {attempt + 1}): {e}. Retrying in {wait}s...")
+            last_err = e
+            time.sleep(wait)
+    raise RuntimeError(f"Failed to fetch Google Trends data: {last_err}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch Google Trends data for Autoware")
+    args = parser.parse_args()
+
+    today = datetime.date.today()
+    end_date = today.strftime("%Y-%m-%d")
+
+    print(f"Fetching Google Trends for '{KEYWORD}' from {START_DATE} to {end_date}...")
+    rows = fetch_trends(end_date)
+
+    output = {
+        "keyword": KEYWORD,
+        "geo": GEO or "worldwide",
+        "monthly": rows,
+        "last_updated": end_date,
+        "note": (
+            "Values are Google Trends relative interest (0-100), not absolute "
+            "search volume. The 100 represents the peak month in the requested range."
+        ),
+    }
+    write_json_output(output, OUTPUT_FILE)
+
+    print(f"\nDone! Generated {OUTPUT_FILE}")
+    print(f"Months collected: {len(rows)}")
+    if rows:
+        print(f"Range: {rows[0]['month']} to {rows[-1]['month']}")
+        peak = max(rows, key=lambda r: r["interest"])
+        print(f"Peak: {peak['month']} (interest={peak['interest']})")
+        print(f"Latest: {rows[-1]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_google_trends.py
+++ b/scripts/get_google_trends.py
@@ -5,10 +5,15 @@ Uses pytrends to query Google Trends for the worldwide monthly relative
 search interest for "Autoware". Values are normalized 0-100 against the
 peak month in the requested range, and represent relative search interest,
 not absolute search volume.
+
+Google rate-limits pytrends aggressively. On fetch failure this script falls
+back to the most recent successful payload cached under
+cache/raw_google_trends_data/, so the dashboard keeps showing the previous
+snapshot instead of dropping the file from the deployed Pages artifact.
 """
 
-import argparse
 import datetime
+import shutil
 import time
 from pathlib import Path
 
@@ -17,6 +22,9 @@ from pytrends.request import TrendReq
 from utils import write_json_output
 
 OUTPUT_FILE = "results/google_trends_history.json"
+CACHE_DIR = Path("cache/raw_google_trends_data")
+CACHE_FILE = CACHE_DIR / "google_trends_history.json"
+
 KEYWORD = "Autoware"
 START_DATE = "2018-01-01"
 GEO = ""  # worldwide
@@ -55,15 +63,30 @@ def fetch_trends(end_date: str) -> list[dict]:
     raise RuntimeError(f"Failed to fetch Google Trends data: {last_err}")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Fetch Google Trends data for Autoware")
-    args = parser.parse_args()
+def restore_from_cache(reason: str) -> bool:
+    """Copy the cached payload to OUTPUT_FILE. Returns True on success."""
+    if not CACHE_FILE.exists():
+        print(f"  No cached fallback at {CACHE_FILE} ({reason})")
+        return False
+    Path(OUTPUT_FILE).parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(CACHE_FILE, OUTPUT_FILE)
+    print(f"  Restored previous Google Trends snapshot from cache ({reason})")
+    return True
 
+
+def main() -> None:
     today = datetime.date.today()
     end_date = today.strftime("%Y-%m-%d")
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
     print(f"Fetching Google Trends for '{KEYWORD}' from {START_DATE} to {end_date}...")
-    rows = fetch_trends(end_date)
+    try:
+        rows = fetch_trends(end_date)
+    except Exception as e:
+        print(f"Fetch failed: {e}")
+        if restore_from_cache(reason=str(e)):
+            return
+        raise
 
     output = {
         "keyword": KEYWORD,
@@ -76,6 +99,7 @@ def main() -> None:
         ),
     }
     write_json_output(output, OUTPUT_FILE)
+    shutil.copyfile(OUTPUT_FILE, CACHE_FILE)
 
     print(f"\nDone! Generated {OUTPUT_FILE}")
     print(f"Months collected: {len(rows)}")


### PR DESCRIPTION
## Summary
- New **External Visibility** dashboard section sitting between APT Downloads and Commits, with a Google Trends chart, a yearly arXiv mentions chart, and four summary cards (Search Interest, arXiv Total, New Papers, Total Citations).
- Three new fetcher scripts that produce the underlying data files (`results/arxiv_mentions_history.json`, `results/arxiv_citations_history.json`, `results/google_trends_history.json`):
  - `scripts/get_arxiv_mentions.py` — arXiv Atom API (`all:autoware`), yearly aggregation.
  - `scripts/get_arxiv_citations.py` — OpenAlex via arXiv DOI (`10.48550/arXiv.<id>`), yearly citation totals (currently used by the summary card; chart was dropped per review).
  - `scripts/get_google_trends.py` — pytrends, monthly worldwide relative interest for the keyword `Autoware`.
- GitHub Actions workflow runs the three new fetchers daily; Google Trends failures are tolerated (`|| echo`) so the rest of the pipeline keeps running.
- `requirements.txt` adds `pytrends>=4.9.2`; CLAUDE.md documents the new pipeline steps and per-fetcher caveats.

## Caveats / Design notes
- arXiv citations are aggregated at **yearly** granularity because that is the finest resolution OpenAlex exposes via `counts_by_year`.
- Google Trends values are **relative interest (0–100)**, not absolute search volume — Google does not publish absolute numbers.
- Google search index counts were intentionally excluded; the Custom Search JSON API's "About N results" estimate is too noisy and lacks historical data.

## Test plan
- [ ] Run `python scripts/get_arxiv_mentions.py` and confirm `results/arxiv_mentions_history.json` is generated with sensible yearly counts.
- [ ] Run `python scripts/get_arxiv_citations.py` and confirm `results/arxiv_citations_history.json` includes `total_citations` and `top_cited_papers`.
- [ ] Run `python scripts/get_google_trends.py` and confirm `results/google_trends_history.json` has 100+ monthly entries (will be flaky if Google rate-limits — workflow keeps going).
- [ ] Copy results to `public/`, serve `cd public && python3 -m http.server 8000`, hard-reload, and verify the new "Visibility" nav link plus charts render correctly.
- [ ] Verify `.github/workflows/measure-contributors.yml` still passes locally with `act` or via a workflow_dispatch run.