### PR TITLE
feat: yearly aggregation, merged contributor section, stacked APT downloads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -69,7 +69,6 @@
           <a href="#stars" class="nav-link active" data-section="stars">Stars</a>
           <a href="#downloads" class="nav-link" data-section="downloads">Downloads</a>
           <a href="#visibility" class="nav-link" data-section="visibility">Visibility</a>
-          <a href="#commits" class="nav-link" data-section="commits">Commits</a>
           <a href="#contributors" class="nav-link" data-section="contributors">Contributors</a>
           <a href="#rankings" class="nav-link" data-section="rankings">Rankings</a>
         </div>
@@ -86,6 +85,9 @@
           <div class="skeleton skeleton-card"></div>
         </div>
         <div id="stars-chart" class="chart-wrapper">
+          <div class="skeleton skeleton-chart"></div>
+        </div>
+        <div id="stars-yearly-chart" class="chart-wrapper">
           <div class="skeleton skeleton-chart"></div>
         </div>
       </section>
@@ -124,9 +126,17 @@
         </div>
       </section>
 
-      <!-- Commits Section -->
-      <section id="commits" class="dashboard-section" data-section>
-        <h2 class="section-heading">Quarterly Activity</h2>
+      <!-- Contributors Section (incl. yearly activity) -->
+      <section id="contributors" class="dashboard-section" data-section>
+        <h2 class="section-heading">Contributor History</h2>
+        <div id="contributors-stats" class="stats-grid">
+          <div class="skeleton skeleton-card"></div>
+          <div class="skeleton skeleton-card"></div>
+          <div class="skeleton skeleton-card"></div>
+        </div>
+        <div id="contributors-chart" class="chart-wrapper">
+          <div class="skeleton skeleton-chart"></div>
+        </div>
         <div id="commits-stats" class="stats-grid">
           <div class="skeleton skeleton-card"></div>
           <div class="skeleton skeleton-card"></div>
@@ -136,19 +146,6 @@
           <div class="skeleton skeleton-card"></div>
         </div>
         <div id="commits-chart" class="chart-wrapper">
-          <div class="skeleton skeleton-chart"></div>
-        </div>
-      </section>
-
-      <!-- Contributors Section -->
-      <section id="contributors" class="dashboard-section" data-section>
-        <h2 class="section-heading">Contributor History</h2>
-        <div id="contributors-stats" class="stats-grid">
-          <div class="skeleton skeleton-card"></div>
-          <div class="skeleton skeleton-card"></div>
-          <div class="skeleton skeleton-card"></div>
-        </div>
-        <div id="contributors-chart" class="chart-wrapper">
           <div class="skeleton skeleton-chart"></div>
         </div>
       </section>

--- a/public/main.js
+++ b/public/main.js
@@ -440,14 +440,12 @@ function renderContributorsChart(json) {
         labels: { formatter: formatNumber },
       },
       {
-        seriesName: 'Total Unique Contributors',
+        seriesName: ['Total Unique Contributors', 'Code Contributors', 'Community Contributors'],
         opposite: true,
         min: 0,
         title: { text: 'Cumulative contributors' },
         labels: { formatter: formatNumber },
       },
-      { seriesName: 'Total Unique Contributors', show: false },
-      { seriesName: 'Total Unique Contributors', show: false },
     ],
     tooltip: { theme: 'dark', shared: true, y: { formatter: formatNumber } },
     colors: ['#FFE66D', ...COLORS.contributors],
@@ -1117,6 +1115,7 @@ if (starsResult.status === 'fulfilled') {
   renderStarsStats(starsResult.value);
 } else {
   showError('#stars-chart', 'Stars history data not available');
+  showError('#stars-yearly-chart', 'Stars history data not available');
 }
 
 if (contributorsResult.status === 'fulfilled') {

--- a/public/main.js
+++ b/public/main.js
@@ -134,6 +134,77 @@ function getChartHeight(base) {
   return base;
 }
 
+// Compute yearly new additions from a cumulative time-series.
+// `history` is an array of objects with {date: 'YYYY-MM-DD', [valueKey]: number}
+// sorted ascending. Returns [{year: 2022, new_count: N}, ...] using the last
+// observed cumulative value within each calendar year.
+function computeYearlyNew(history, valueKey) {
+  if (!history || history.length === 0) return [];
+  const lastByYear = {};
+  history.forEach(item => {
+    const y = new Date(item.date).getUTCFullYear();
+    lastByYear[y] = item[valueKey];
+  });
+  const years = Object.keys(lastByYear).map(Number).sort((a, b) => a - b);
+  const out = [];
+  let prev = 0;
+  years.forEach(y => {
+    const total = lastByYear[y];
+    out.push({ year: y, new_count: total - prev, cumulative: total });
+    prev = total;
+  });
+  return out;
+}
+
+function createYearlyComboOptions({ yearly, title, barName, lineName, color }) {
+  const categories = yearly.map(y => String(y.year));
+  return {
+    series: [
+      { name: barName, type: 'column', data: yearly.map(y => y.new_count) },
+      { name: lineName, type: 'line', data: yearly.map(y => y.cumulative) },
+    ],
+    chart: {
+      type: 'line',
+      height: getChartHeight(360),
+      toolbar: { show: true },
+      background: 'transparent',
+      stacked: false,
+    },
+    title: {
+      text: title,
+      align: 'left',
+      style: { fontSize: '16px', fontFamily: 'Outfit, sans-serif', fontWeight: 600 },
+    },
+    stroke: { width: [0, 3], curve: 'smooth' },
+    plotOptions: { bar: { borderRadius: 3, columnWidth: '55%' } },
+    dataLabels: { enabled: false },
+    xaxis: { categories },
+    yaxis: [
+      {
+        seriesName: barName,
+        min: 0,
+        title: { text: barName },
+        labels: { formatter: formatNumber },
+      },
+      {
+        seriesName: lineName,
+        opposite: true,
+        min: 0,
+        title: { text: lineName },
+        labels: { formatter: formatNumber },
+      },
+    ],
+    tooltip: { theme: 'dark', shared: true, y: { formatter: formatNumber } },
+    colors: [color, '#FFE66D'],
+    legend: {
+      position: 'bottom', horizontalAlign: 'center',
+      fontSize: '12px', fontFamily: 'Outfit, sans-serif',
+      markers: { width: 10, height: 10, radius: 3 },
+    },
+    grid: { row: { opacity: 0 } },
+  };
+}
+
 // =============================================================================
 // Chart Configuration
 // =============================================================================
@@ -246,6 +317,21 @@ function renderStarsChart(json) {
   new ApexCharts(chartEl, options).render();
 }
 
+function renderStarsYearlyChart(json) {
+  const chartEl = document.querySelector('#stars-yearly-chart');
+  chartEl.innerHTML = '';
+  const yearly = computeYearlyNew(json.total_stars_history || [], 'star_count');
+  if (yearly.length === 0) return;
+  const options = createYearlyComboOptions({
+    yearly,
+    title: 'New Stars Per Year (with Cumulative Total)',
+    barName: 'New stars / year',
+    lineName: 'Cumulative stars',
+    color: COLORS.stars[0],
+  });
+  new ApexCharts(chartEl, options).render();
+}
+
 function renderStarsStats(json) {
   const latestEntry = getLastEntry(json.total_stars_history);
   const date = latestEntry ? formatDate(latestEntry.date) : 'N/A';
@@ -282,28 +368,96 @@ function renderContributorsChart(json) {
   const chartEl = document.querySelector('#contributors-chart');
   chartEl.innerHTML = '';
 
+  // Build yearly buckets from the full contributors history; take the last
+  // observed cumulative value within each calendar year as that year's snapshot.
+  const total = json.autoware_contributors || [];
+  const code = json.autoware_code_contributors || [];
+  const community = json.autoware_community_contributors || [];
+
+  const yearSet = new Set();
+  [total, code, community].forEach(arr => arr.forEach(item => {
+    yearSet.add(new Date(item.date).getUTCFullYear());
+  }));
+  const years = [...yearSet].sort((a, b) => a - b);
+
+  function lastValueByYear(history, valueKey) {
+    const map = {};
+    history.forEach(item => {
+      const y = new Date(item.date).getUTCFullYear();
+      map[y] = item[valueKey];
+    });
+    // Forward-fill years where this series had no observation (carry the prior
+    // cumulative value so the line stays monotonic across the full timeline).
+    const out = [];
+    let prev = null;
+    years.forEach(y => {
+      if (map[y] !== undefined) prev = map[y];
+      out.push(prev);
+    });
+    return out;
+  }
+
+  const totalByYear = lastValueByYear(total, 'contributors_count');
+  // New contributors per year = year-over-year delta of the cumulative total.
+  const newPerYear = totalByYear.map((v, i) => {
+    if (v === null) return 0;
+    const prev = i === 0 ? 0 : (totalByYear[i - 1] ?? 0);
+    return v - prev;
+  });
+
   const series = [
-    {
-      name: 'Total Unique Contributors',
-      data: mapToChartData(json.autoware_contributors, 'contributors_count'),
-    },
-    {
-      name: 'Code Contributors',
-      data: mapToChartData(json.autoware_code_contributors, 'contributors_count'),
-    },
-    {
-      name: 'Community Contributors',
-      data: mapToChartData(json.autoware_community_contributors, 'contributors_count'),
-    },
+    { name: 'New contributors / year', type: 'column', data: newPerYear },
+    { name: 'Total Unique Contributors', type: 'line', data: totalByYear },
+    { name: 'Code Contributors', type: 'line', data: lastValueByYear(code, 'contributors_count') },
+    { name: 'Community Contributors', type: 'line', data: lastValueByYear(community, 'contributors_count') },
   ];
 
-  const options = createChartOptions({
+  const options = {
     series,
-    title: 'Contributor Growth Over Time',
-    yAxisTitle: 'Number of Contributors',
-    colors: COLORS.contributors,
-    showLegend: true,
-  });
+    chart: {
+      type: 'line',
+      height: getChartHeight(420),
+      stacked: false,
+      zoom: { enabled: false },
+      background: 'transparent',
+      toolbar: { show: true },
+    },
+    title: {
+      text: 'Contributor Growth Over Time',
+      align: 'left',
+      style: { fontSize: '16px', fontFamily: 'Outfit, sans-serif', fontWeight: 600 },
+    },
+    stroke: { width: [0, 3, 2, 2], curve: 'smooth' },
+    plotOptions: { bar: { borderRadius: 4, columnWidth: '60%' } },
+    markers: { size: [0, 4, 3, 3] },
+    dataLabels: { enabled: false },
+    xaxis: { categories: years.map(String) },
+    yaxis: [
+      {
+        seriesName: 'New contributors / year',
+        min: 0,
+        title: { text: 'New contributors / year' },
+        labels: { formatter: formatNumber },
+      },
+      {
+        seriesName: 'Total Unique Contributors',
+        opposite: true,
+        min: 0,
+        title: { text: 'Cumulative contributors' },
+        labels: { formatter: formatNumber },
+      },
+      { seriesName: 'Total Unique Contributors', show: false },
+      { seriesName: 'Total Unique Contributors', show: false },
+    ],
+    tooltip: { theme: 'dark', shared: true, y: { formatter: formatNumber } },
+    colors: ['#FFE66D', ...COLORS.contributors],
+    legend: {
+      position: 'bottom', horizontalAlign: 'center',
+      fontSize: '12px', fontFamily: 'Outfit, sans-serif',
+      markers: { width: 10, height: 10, radius: 3 },
+    },
+    grid: { row: { opacity: 0 } },
+  };
 
   new ApexCharts(chartEl, options).render();
 }
@@ -313,7 +467,7 @@ function renderContributorsStats(json) {
   const date = latestEntry ? formatDate(latestEntry.date) : 'N/A';
 
   const cards = [
-    createMetricCard('Total Contributors', latestEntry?.contributors_count || 0, 'cyan', `Updated ${date}`),
+    createMetricCard('Total Unique Contributors', latestEntry?.contributors_count || 0, 'cyan', `Updated ${date}`),
     createMetricCard('Code Contributors', getLastEntry(json.autoware_code_contributors)?.contributors_count || 0, 'coral'),
     createMetricCard('Community Contributors', getLastEntry(json.autoware_community_contributors)?.contributors_count || 0, 'teal'),
   ];
@@ -329,12 +483,10 @@ function renderDownloadsChart(json) {
   const chartEl = document.querySelector('#downloads-chart');
   chartEl.textContent = '';
 
-  const cumulative = json.cumulative;
+  // Stacked area: Humble + Jazzy + Rolling sums to Total at each point.
+  // Restrict the displayed window to 2024-01 onward.
+  const cumulative = (json.cumulative || []).filter(item => item.date >= '2024-01');
   const series = [
-    {
-      name: 'Total',
-      data: cumulative.map(item => [new Date(item.date + '-01'), item.total]),
-    },
     {
       name: 'Humble',
       data: cumulative.map(item => [new Date(item.date + '-01'), item.humble]),
@@ -349,13 +501,48 @@ function renderDownloadsChart(json) {
     },
   ];
 
-  const options = createChartOptions({
+  const options = {
     series,
-    title: 'APT Package Download Growth (Cumulative)',
-    yAxisTitle: 'Total Downloads',
-    colors: COLORS.downloads,
-    showLegend: true,
-  });
+    chart: {
+      type: 'area',
+      height: getChartHeight(400),
+      stacked: true,
+      zoom: { enabled: true },
+      background: 'transparent',
+      toolbar: { show: true },
+    },
+    title: {
+      text: 'APT Package Download Growth (Cumulative, Stacked by Distro)',
+      align: 'left',
+      style: { fontSize: '16px', fontFamily: 'Outfit, sans-serif', fontWeight: 600 },
+    },
+    dataLabels: { enabled: false },
+    stroke: { width: 2, curve: 'smooth' },
+    fill: {
+      type: 'gradient',
+      gradient: { shadeIntensity: 1, opacityFrom: 0.55, opacityTo: 0.15 },
+    },
+    xaxis: { type: 'datetime' },
+    yaxis: {
+      min: 0,
+      title: { text: 'Total Downloads' },
+      labels: { formatter: formatNumber },
+    },
+    tooltip: {
+      theme: 'dark',
+      shared: true,
+      y: { formatter: formatNumber },
+    },
+    colors: ['#FF6B6B', '#4ECDC4', '#FFE66D'],
+    legend: {
+      position: 'bottom',
+      horizontalAlign: 'center',
+      fontSize: '12px',
+      fontFamily: 'Outfit, sans-serif',
+      markers: { width: 10, height: 10, radius: 3 },
+    },
+    grid: { row: { opacity: 0 } },
+  };
 
   new ApexCharts(chartEl, options).render();
 }
@@ -471,24 +658,24 @@ function renderCommitsChart(commitsJson, activityJson) {
   const prHistory = activityJson ? (activityJson.total_merged_prs_history || []) : [];
   const issueHistory = activityJson ? (activityJson.total_resolved_issues_history || []) : [];
 
-  // Merge quarters from all series
-  const quarterSet = new Set();
-  commitHistory.forEach(item => quarterSet.add(item.quarter));
-  prHistory.forEach(item => quarterSet.add(item.quarter));
-  issueHistory.forEach(item => quarterSet.add(item.quarter));
-  const categories = Array.from(quarterSet).sort();
+  // Merge years from all series
+  const yearSet = new Set();
+  commitHistory.forEach(item => yearSet.add(item.year));
+  prHistory.forEach(item => yearSet.add(item.year));
+  issueHistory.forEach(item => yearSet.add(item.year));
+  const categories = Array.from(yearSet).sort();
 
   const commitMap = {};
-  commitHistory.forEach(item => { commitMap[item.quarter] = item.commit_count; });
+  commitHistory.forEach(item => { commitMap[item.year] = item.commit_count; });
   const prMap = {};
-  prHistory.forEach(item => { prMap[item.quarter] = item.merged_pr_count; });
+  prHistory.forEach(item => { prMap[item.year] = item.merged_pr_count; });
   const issueMap = {};
-  issueHistory.forEach(item => { issueMap[item.quarter] = item.resolved_issue_count; });
+  issueHistory.forEach(item => { issueMap[item.year] = item.resolved_issue_count; });
 
   const series = [
-    { name: 'Commits', data: categories.map(q => commitMap[q] || 0) },
-    { name: 'Merged PRs', data: categories.map(q => prMap[q] || 0) },
-    { name: 'Resolved Issues', data: categories.map(q => issueMap[q] || 0) },
+    { name: 'Commits', data: categories.map(y => commitMap[y] || 0) },
+    { name: 'Merged PRs', data: categories.map(y => prMap[y] || 0) },
+    { name: 'Resolved Issues', data: categories.map(y => issueMap[y] || 0) },
   ];
 
   const options = {
@@ -500,7 +687,7 @@ function renderCommitsChart(commitsJson, activityJson) {
       background: 'transparent',
     },
     title: {
-      text: 'Quarterly Activity (All Repositories)',
+      text: 'Yearly Activity (All Repositories)',
       align: 'left',
       style: { fontSize: '16px', fontFamily: 'Outfit, sans-serif', fontWeight: 600 },
     },
@@ -553,11 +740,11 @@ function renderCommitsStats(commitsJson, activityJson) {
 
   const cards = [
     createMetricCard('Total Commits', totalCommits, 'cyan', 'Since 2022'),
-    createMetricCard('Latest Quarter Commits', latestCommit?.commit_count || 0, 'cyan', latestCommit?.quarter || 'N/A'),
+    createMetricCard('Latest Year Commits', latestCommit?.commit_count || 0, 'cyan', latestCommit?.year || 'N/A'),
     createMetricCard('Total Merged PRs', totalPRs, 'coral', 'Since 2022'),
-    createMetricCard('Latest Quarter Merged PRs', latestPR?.merged_pr_count || 0, 'coral', latestPR?.quarter || 'N/A'),
+    createMetricCard('Latest Year Merged PRs', latestPR?.merged_pr_count || 0, 'coral', latestPR?.year || 'N/A'),
     createMetricCard('Total Resolved Issues', totalIssues, 'teal', 'Since 2022'),
-    createMetricCard('Latest Quarter Resolved Issues', latestIssue?.resolved_issue_count || 0, 'teal', latestIssue?.quarter || 'N/A'),
+    createMetricCard('Latest Year Resolved Issues', latestIssue?.resolved_issue_count || 0, 'teal', latestIssue?.year || 'N/A'),
   ];
 
   renderMetricCards('commits-stats', cards);
@@ -926,6 +1113,7 @@ const [
 // 3. Render each independently (error per section)
 if (starsResult.status === 'fulfilled') {
   renderStarsChart(starsResult.value);
+  renderStarsYearlyChart(starsResult.value);
   renderStarsStats(starsResult.value);
 } else {
   showError('#stars-chart', 'Stars history data not available');

--- a/scripts/calculate_activity_history.py
+++ b/scripts/calculate_activity_history.py
@@ -7,15 +7,10 @@ from utils import parse_github_datetime, load_json_file, write_json_output
 
 
 class ActivityHistoryAnalyzer:
-    """Class to analyze quarterly merged PRs and resolved issues from contributor data"""
+    """Class to analyze yearly merged PRs and resolved issues from contributor data"""
 
     def __init__(self):
         self.start_date = datetime.date(2022, 1, 1)
-
-    def _date_to_quarter(self, d: datetime.date) -> str:
-        """Convert a date to quarter string like '2022-Q1'"""
-        quarter = (d.month - 1) // 3 + 1
-        return f"{d.year}-Q{quarter}"
 
     def extract_merged_pr_dates(self, pr_data: List[Dict]) -> List[datetime.date]:
         """Extract merge dates from raw PR data"""
@@ -51,24 +46,23 @@ class ActivityHistoryAnalyzer:
                 continue
         return dates
 
-    def count_per_quarter(self, dates: List[datetime.date]) -> Dict[str, int]:
-        """Count items per quarter"""
-        per_quarter = defaultdict(int)
+    def count_per_year(self, dates: List[datetime.date]) -> Dict[str, int]:
+        """Count items per year"""
+        per_year = defaultdict(int)
         for day in dates:
-            quarter = self._date_to_quarter(day)
-            per_quarter[quarter] += 1
-        return dict(per_quarter)
+            per_year[str(day.year)] += 1
+        return dict(per_year)
 
-    def generate_quarter_history(self, per_quarter: Dict[str, int], count_key: str) -> List[Dict]:
-        """Generate sorted quarterly history list"""
+    def generate_year_history(self, per_year: Dict[str, int], count_key: str) -> List[Dict]:
+        """Generate sorted yearly history list"""
         return [
-            {"quarter": q, count_key: per_quarter[q]}
-            for q in sorted(per_quarter.keys())
+            {"year": y, count_key: per_year[y]}
+            for y in sorted(per_year.keys())
         ]
 
 
 def main():
-    """Main function to process quarterly activity history"""
+    """Main function to process yearly activity history"""
     print("Processing activity history...")
 
     analyzer = ActivityHistoryAnalyzer()
@@ -89,24 +83,24 @@ def main():
         if pr_data:
             pr_dates = analyzer.extract_merged_pr_dates(pr_data)
             all_pr_dates.extend(pr_dates)
-            per_quarter = analyzer.count_per_quarter(pr_dates)
-            output_data[f"{repository}_merged_prs_history"] = analyzer.generate_quarter_history(per_quarter, "merged_pr_count")
+            per_year = analyzer.count_per_year(pr_dates)
+            output_data[f"{repository}_merged_prs_history"] = analyzer.generate_year_history(per_year, "merged_pr_count")
 
         # Resolved issues
         issue_data = load_json_file(str(issue_path))
         if issue_data:
             issue_dates = analyzer.extract_resolved_issue_dates(issue_data)
             all_issue_dates.extend(issue_dates)
-            per_quarter = analyzer.count_per_quarter(issue_dates)
-            output_data[f"{repository}_resolved_issues_history"] = analyzer.generate_quarter_history(per_quarter, "resolved_issue_count")
+            per_year = analyzer.count_per_year(issue_dates)
+            output_data[f"{repository}_resolved_issues_history"] = analyzer.generate_year_history(per_year, "resolved_issue_count")
 
     # Generate totals
     print("Generating total activity history...")
-    total_pr_quarter = analyzer.count_per_quarter(all_pr_dates)
-    output_data["total_merged_prs_history"] = analyzer.generate_quarter_history(total_pr_quarter, "merged_pr_count")
+    total_pr_year = analyzer.count_per_year(all_pr_dates)
+    output_data["total_merged_prs_history"] = analyzer.generate_year_history(total_pr_year, "merged_pr_count")
 
-    total_issue_quarter = analyzer.count_per_quarter(all_issue_dates)
-    output_data["total_resolved_issues_history"] = analyzer.generate_quarter_history(total_issue_quarter, "resolved_issue_count")
+    total_issue_year = analyzer.count_per_year(all_issue_dates)
+    output_data["total_resolved_issues_history"] = analyzer.generate_year_history(total_issue_year, "resolved_issue_count")
 
     output_file = "results/activity_history.json"
     write_json_output(output_data, output_file)

--- a/scripts/calculate_commits_history.py
+++ b/scripts/calculate_commits_history.py
@@ -7,15 +7,10 @@ from utils import parse_github_datetime, load_json_file, write_json_output
 
 
 class CommitsHistoryAnalyzer:
-    """Class to analyze and generate quarterly commit history from commit data"""
+    """Class to analyze and generate yearly commit history from commit data"""
 
     def __init__(self):
         self.start_date = datetime.date(2022, 1, 1)
-
-    def _date_to_quarter(self, d: datetime.date) -> str:
-        """Convert a date to quarter string like '2022-Q1'"""
-        quarter = (d.month - 1) // 3 + 1
-        return f"{d.year}-Q{quarter}"
 
     def extract_commit_dates(self, commit_data: List[Dict]) -> List[datetime.date]:
         """Extract commit dates from raw commit data"""
@@ -36,26 +31,25 @@ class CommitsHistoryAnalyzer:
 
         return dates
 
-    def count_commits_per_quarter(self, dates: List[datetime.date]) -> Dict[str, int]:
-        """Count commits per quarter"""
-        per_quarter = defaultdict(int)
+    def count_commits_per_year(self, dates: List[datetime.date]) -> Dict[str, int]:
+        """Count commits per year"""
+        per_year = defaultdict(int)
 
         for day in dates:
-            quarter = self._date_to_quarter(day)
-            per_quarter[quarter] += 1
+            per_year[str(day.year)] += 1
 
-        return dict(per_quarter)
+        return dict(per_year)
 
-    def generate_quarter_history(self, per_quarter: Dict[str, int]) -> List[Dict]:
-        """Generate sorted quarterly history list"""
+    def generate_year_history(self, per_year: Dict[str, int]) -> List[Dict]:
+        """Generate sorted yearly history list"""
         return [
-            {"quarter": q, "commit_count": per_quarter[q]}
-            for q in sorted(per_quarter.keys())
+            {"year": y, "commit_count": per_year[y]}
+            for y in sorted(per_year.keys())
         ]
 
 
 def main():
-    """Main function to process quarterly commit history"""
+    """Main function to process yearly commit history"""
     print("Processing commit history...")
 
     analyzer = CommitsHistoryAnalyzer()
@@ -77,15 +71,15 @@ def main():
         dates = analyzer.extract_commit_dates(commit_data)
         all_dates.extend(dates)
 
-        per_quarter = analyzer.count_commits_per_quarter(dates)
-        history = analyzer.generate_quarter_history(per_quarter)
+        per_year = analyzer.count_commits_per_year(dates)
+        history = analyzer.generate_year_history(per_year)
 
         output_data[f"{repository}_commits_history"] = history
 
     # Generate total commits history
     print("Generating total commits history...")
-    total_per_quarter = analyzer.count_commits_per_quarter(all_dates)
-    total_history = analyzer.generate_quarter_history(total_per_quarter)
+    total_per_year = analyzer.count_commits_per_year(all_dates)
+    total_history = analyzer.generate_year_history(total_per_year)
     output_data["total_commits_history"] = total_history
 
     output_file = "results/commits_history.json"
@@ -94,7 +88,7 @@ def main():
     print(f"\nDone! Generated {output_file}")
     print(f"Processed {len(repositories)} repositories")
     print(f"Total commits (since 2022): {len(all_dates)}")
-    print(f"Total quarters: {len(total_history)}")
+    print(f"Total years: {len(total_history)}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- **APT Package Download Growth**: stacked area by ROS distro (Humble + Jazzy + Rolling), x-axis starts at 2024-01.
- **Stars**: keep the per-repo cumulative chart and add a yearly bars + cumulative line combo chart (dual axis).
- **Contributors**: merge the cumulative line chart and yearly bars into a single combo chart on a categorical year axis (matches the bar thickness of Yearly Activity). Removes the now-redundant standalone yearly chart and the duplicate "Cumulative contributors" line. Renames the metric card "Total Contributors" -> "Total Unique Contributors".
- **Activity**: re-aggregate commits / merged PRs / resolved issues per year instead of per quarter, and fold them into the Contributor History section. The standalone "Quarterly Activity" section and its nav link are removed.
- `calculate_commits_history.py` and `calculate_activity_history.py` now emit `{"year": "YYYY", ...}` entries.

## Test plan
- [ ] `python3 scripts/calculate_commits_history.py` produces yearly buckets in `results/commits_history.json`.
- [ ] `python3 scripts/calculate_activity_history.py` produces yearly buckets in `results/activity_history.json`.
- [ ] `cd public && python3 -m http.server 8000` and verify each chart in the browser:
  - APT Downloads is a stacked area starting at Jan 2024.
  - Stars section shows the per-repo line chart plus the new yearly bars + cumulative combo chart.
  - Contributor History shows one combo chart (bars + 3 cumulative lines) and the Yearly Activity bar chart with thick bars.
  - Top nav has Stars / Downloads / Visibility / Contributors / Rankings (no Commits link).