### PR TITLE
fix: keep pipeline alive when arXiv rate-limits the mentions fetch

### DIFF
--- a/scripts/get_arxiv_mentions.py
+++ b/scripts/get_arxiv_mentions.py
@@ -8,6 +8,7 @@ time-series of new submissions plus a cumulative total.
 
 import argparse
 import datetime
+import os
 import time
 import xml.etree.ElementTree as ET
 from collections import defaultdict
@@ -30,8 +31,36 @@ MAX_RETRIES = 5
 START_MONTH = "2018-01"
 
 
-def fetch_page(start: int, max_results: int) -> str:
-    """Fetch one page of results from arXiv API. Returns Atom XML text."""
+def build_session() -> requests.Session:
+    """Build a session with a descriptive User-Agent.
+
+    arXiv rate-limits the default ``python-requests`` User-Agent aggressively;
+    identifying the client (project + contact) makes 429s far less frequent.
+    """
+    s = requests.Session()
+    mailto = os.environ.get("ARXIV_MAILTO", "yutaka.kondo@youtalk.jp")
+    s.headers["User-Agent"] = f"autoware-contributor-metrics (mailto:{mailto})"
+    return s
+
+
+def _retry_after_seconds(resp: requests.Response | None, default: float) -> float:
+    """Return the server-requested backoff from a Retry-After header, else default."""
+    if resp is None:
+        return default
+    value = resp.headers.get("Retry-After")
+    if value:
+        try:
+            return max(float(value), default)
+        except ValueError:
+            pass
+    return default
+
+
+def fetch_page(session: requests.Session, start: int, max_results: int) -> str:
+    """Fetch one page of results from arXiv API. Returns Atom XML text.
+
+    Raises RuntimeError if every retry is exhausted (e.g. persistent 429).
+    """
     params = {
         "search_query": SEARCH_QUERY,
         "start": start,
@@ -41,11 +70,15 @@ def fetch_page(start: int, max_results: int) -> str:
     }
     for attempt in range(MAX_RETRIES):
         try:
-            resp = requests.get(ARXIV_API_URL, params=params, timeout=60)
+            resp = session.get(ARXIV_API_URL, params=params, timeout=60)
             resp.raise_for_status()
             return resp.text
         except requests.exceptions.RequestException as e:
+            if attempt == MAX_RETRIES - 1:
+                break
             wait = 2 ** attempt * REQUEST_DELAY_SEC
+            if getattr(e, "response", None) is not None and e.response.status_code in (429, 503):
+                wait = _retry_after_seconds(e.response, wait)
             print(f"  Error (attempt {attempt + 1}): {e}. Retrying in {wait:.1f}s...")
             time.sleep(wait)
     raise RuntimeError(f"Failed to fetch arXiv page at start={start} after {MAX_RETRIES} retries")
@@ -80,13 +113,23 @@ def parse_entries(xml_text: str) -> list[dict]:
     return entries
 
 
-def fetch_all(known_ids: set[str]) -> list[dict]:
-    """Fetch all matching entries, skipping those already in known_ids when possible."""
+def fetch_all(session: requests.Session, known_ids: set[str]) -> list[dict]:
+    """Fetch all matching entries, skipping those already in known_ids when possible.
+
+    On a persistent fetch failure (e.g. arXiv 429 rate-limiting) this returns the
+    entries collected so far instead of raising, so the caller can fall back to the
+    existing cache and keep the pipeline running.
+    """
     all_entries: list[dict] = []
     start = 0
     while True:
         print(f"Fetching arXiv start={start}...")
-        xml_text = fetch_page(start, PAGE_SIZE)
+        try:
+            xml_text = fetch_page(session, start, PAGE_SIZE)
+        except RuntimeError as e:
+            print(f"  {e}")
+            print("  arXiv unavailable; continuing with data collected so far.")
+            break
         entries = parse_entries(xml_text)
         if not entries:
             print("  No more entries.")
@@ -149,11 +192,17 @@ def main() -> None:
     known_ids = set(cached_by_id.keys())
     print(f"Loaded {len(known_ids)} cached papers")
 
-    fetched = fetch_all(known_ids)
+    session = build_session()
+    fetched = fetch_all(session, known_ids)
     for e in fetched:
         cached_by_id[e["arxiv_id"]] = e
 
     papers = sorted(cached_by_id.values(), key=lambda x: x.get("published", ""))
+    if not papers:
+        # Nothing cached and the fetch failed: don't clobber an existing output
+        # with an empty one — leave the previous snapshot in place.
+        print("No papers available (empty cache and fetch failed); keeping any existing output.")
+        return
     write_json_output(papers, CACHE_FILE)
     print(f"Cached {len(papers)} total papers")
 


### PR DESCRIPTION
## Problem

The daily `measure_contributors` job has been failing frequently — 10 of the last 20 scheduled runs. Every failure is the same: arXiv's API returns HTTP 429 (rate limiting) to the GitHub runner, `get_arxiv_mentions.py` exhausts its 5 retries and raises `RuntimeError`, exiting non-zero.

Because the workflow runs every script in a single `bash -e` block (the "Execute script" step), that one transient external failure aborts the whole pipeline before any deploy step runs. So a temporary arXiv hiccup leaves the entire dashboard — stars, contributors, commits, everything — stale for the day, not just the arXiv section.

## Fix

Apply the same graceful-degradation approach that `get_google_trends.py` and `get_arxiv_citations.py` already use for their external APIs, scoped to `scripts/get_arxiv_mentions.py`:

- On a persistent fetch failure, keep the papers already in `cache/raw_arxiv_data/papers.json` and regenerate `arxiv_mentions_history.json` from them instead of crashing. The pipeline continues and deploys.
- Reduce how often arXiv throttles us in the first place: send a descriptive `User-Agent` (arXiv rate-limits the default `python-requests` UA harder — this mirrors what the OpenAlex fetcher already does), honor the `Retry-After` header on 429/503, and drop the wasted sleep after the final retry attempt (saves up to ~56s of idle CI time on a hard failure).
- Guard against clobbering an existing output with an empty one when both the cache is empty and the fetch fails.

## Verification

Verified locally with a harness that forces the arXiv HTTP call to a persistent 429:

- **429 resilience** — previously crashed with `RuntimeError`; now degrades gracefully and regenerates the output from cache.
- **Happy path** — a successful 200 still merges new papers, and the descriptive `User-Agent` is sent.
- **Retry-After** — a `Retry-After: 42` header is honored, and there is no sleep after the final attempt (4 sleeps for 5 retries).

No behavior change to any other script; the diff is limited to `scripts/get_arxiv_mentions.py`.