### PR TITLE
fix: stop skipping the first item of every paginated series

### DIFF
--- a/scripts/get_commits.py
+++ b/scripts/get_commits.py
@@ -1,44 +1,10 @@
 import sys
 import argparse
-from typing import List, Dict, Optional
+from typing import List, Dict
 from repositories import REPOSITORIES
 from github_client import GitHubGraphQLClient, fetch_with_cache
 
 CACHE_DIR = "cache/raw_commit_data"
-
-
-def get_first_cursor(client: GitHubGraphQLClient, repository: str) -> Optional[str]:
-    """Get the first cursor for a repository's commit history"""
-    query = """
-    query($repository: String!) {
-        repository(owner:"autowarefoundation", name:$repository) {
-            defaultBranchRef {
-                target {
-                    ... on Commit {
-                        history(first:1) {
-                            edges {
-                                cursor
-                                node {
-                                    oid
-                                    committedDate
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """
-
-    data = client.execute_query(query, {"repository": repository})
-    default_branch = data["data"]["repository"].get("defaultBranchRef")
-    if not default_branch:
-        return None
-    edges = default_branch["target"]["history"]["edges"]
-    if not edges:
-        return None
-    return edges[0]["cursor"]
 
 
 def get_commits(client: GitHubGraphQLClient, repository: str, start_cursor: str = None) -> List[Dict]:
@@ -54,20 +20,15 @@ def get_commits(client: GitHubGraphQLClient, repository: str, start_cursor: str 
     else:
         print(f"Retrieving commits for {repository}...")
 
-    # Use provided cursor or get the first one
-    if start_cursor:
-        cursor = start_cursor
-    else:
-        cursor = get_first_cursor(client, repository)
-        if cursor is None:
-            print(f"No commits found for {repository}")
-            return []
-
+    # `after: null` starts at the very first commit. Seeding this with the first
+    # commit's own cursor would silently skip that commit, because `after` is
+    # exclusive.
+    cursor = start_cursor
     all_edges = []
     page_count = 0
 
     query = """
-    query($cursor: String!, $repository: String!) {
+    query($cursor: String, $repository: String!) {
         repository(owner:"autowarefoundation", name:$repository) {
             defaultBranchRef {
                 target {
@@ -93,7 +54,7 @@ def get_commits(client: GitHubGraphQLClient, repository: str, start_cursor: str 
     }
     """
 
-    while cursor:
+    while True:
         print(f"Fetching page {page_count + 1} for {repository}...")
         data = client.execute_query(query, {"cursor": cursor, "repository": repository})
 
@@ -102,13 +63,11 @@ def get_commits(client: GitHubGraphQLClient, repository: str, start_cursor: str 
             break
 
         edges = default_branch["target"]["history"]["edges"]
+        if not edges:
+            break
         all_edges.extend(edges)
         page_count += 1
-
-        if len(edges) > 0:
-            cursor = edges[-1]["cursor"]
-        else:
-            cursor = None
+        cursor = edges[-1]["cursor"]
 
     print(f"Retrieved {len(all_edges)} commits for {repository}")
     return all_edges

--- a/scripts/get_contributors.py
+++ b/scripts/get_contributors.py
@@ -1,31 +1,10 @@
 import sys
 import argparse
-from typing import List, Dict, Optional
+from typing import List, Dict
 from repositories import REPOSITORIES
 from github_client import GitHubGraphQLClient, fetch_with_cache
 
 CACHE_DIR = "cache/raw_contributor_data"
-
-
-def get_first_cursor(client: GitHubGraphQLClient, contributor_type: str, repository: str) -> Optional[str]:
-    """Get the first cursor for a repository and contributor type"""
-    query = f"""
-    query($repository: String!) {{
-        repository(owner:"autowarefoundation", name:$repository) {{
-            {contributor_type}(first:1) {{
-                edges {{
-                    cursor
-                }}
-            }}
-        }}
-    }}
-    """
-
-    data = client.execute_query(query, {"repository": repository})
-    edges = data["data"]["repository"][contributor_type]["edges"]
-    if not edges:
-        return None
-    return edges[0]["cursor"]
 
 
 def get_contributors(client: GitHubGraphQLClient, contributor_type: str, repository: str, start_cursor: str = None) -> List[Dict]:
@@ -42,15 +21,10 @@ def get_contributors(client: GitHubGraphQLClient, contributor_type: str, reposit
     else:
         print(f"Retrieving {contributor_type} for {repository}...")
 
-    # Use provided cursor or get the first one
-    if start_cursor:
-        cursor = start_cursor
-    else:
-        cursor = get_first_cursor(client, contributor_type, repository)
-        if cursor is None:
-            print(f"No {contributor_type} found for {repository}")
-            return []
-
+    # `after: null` starts at the very first item. Seeding this with the first
+    # item's own cursor would silently skip that item, because `after` is
+    # exclusive.
+    cursor = start_cursor
     all_edges = []
     page_count = 0
 
@@ -77,7 +51,7 @@ def get_contributors(client: GitHubGraphQLClient, contributor_type: str, reposit
                         closedAt"""
 
     query = f"""
-    query($cursor: String!, $repository: String!) {{
+    query($cursor: String, $repository: String!) {{
         repository(owner:"autowarefoundation", name:$repository) {{
             {contributor_type}(first:100, after: $cursor) {{
                 totalCount
@@ -106,18 +80,16 @@ def get_contributors(client: GitHubGraphQLClient, contributor_type: str, reposit
     }}
     """
 
-    while cursor:
+    while True:
         print(f"Fetching page {page_count + 1} for {repository} {contributor_type}...")
         data = client.execute_query(query, {"cursor": cursor, "repository": repository})
 
         edges = data["data"]["repository"][contributor_type]["edges"]
+        if not edges:
+            break
         all_edges.extend(edges)
         page_count += 1
-
-        if len(edges) > 0:
-            cursor = edges[-1]["cursor"]
-        else:
-            cursor = None
+        cursor = edges[-1]["cursor"]
 
     print(f"Retrieved {len(all_edges)} {contributor_type} for {repository}")
     return all_edges

--- a/scripts/get_stargazers.py
+++ b/scripts/get_stargazers.py
@@ -1,38 +1,11 @@
 import sys
 import argparse
-from typing import List, Dict, Optional, Set
+from typing import List, Dict, Set
 from pathlib import Path
 from repositories import REPOSITORIES
 from github_client import GitHubGraphQLClient, fetch_with_cache
 
 CACHE_DIR = "cache/raw_stargazer_data"
-
-
-def get_first_cursor(client: GitHubGraphQLClient, repository: str) -> Optional[str]:
-    """Get the first cursor for a repository"""
-    query = """
-    query($repository: String!) {
-        repository(owner:"autowarefoundation", name:$repository) {
-            stargazers(first:1) {
-                totalCount
-                edges {
-                    cursor
-                    starredAt
-                    node {
-                        name
-                        login
-                    }
-                }
-            }
-        }
-    }
-    """
-
-    data = client.execute_query(query, {"repository": repository})
-    edges = data["data"]["repository"]["stargazers"]["edges"]
-    if not edges:
-        return None
-    return edges[0]["cursor"]
 
 
 def get_stargazers(client: GitHubGraphQLClient, repository: str, start_cursor: str = None) -> List[Dict]:
@@ -41,27 +14,23 @@ def get_stargazers(client: GitHubGraphQLClient, repository: str, start_cursor: s
     Args:
         client: GitHubGraphQLClient instance
         repository: Repository name
-        start_cursor: Optional cursor to start fetching from (for incremental updates)
+        start_cursor: Optional cursor to resume from (for incremental updates).
+                      None starts at the very first stargazer.
     """
     if start_cursor:
         print(f"Retrieving new stargazers for {repository} (incremental update)...")
     else:
         print(f"Retrieving stargazers for {repository}...")
 
-    # Use provided cursor or get the first one
-    if start_cursor:
-        cursor = start_cursor
-    else:
-        cursor = get_first_cursor(client, repository)
-        if cursor is None:
-            print(f"No stargazers found for {repository}")
-            return []
-
+    # `after: null` starts at the very first stargazer. Seeding this with the
+    # first stargazer's own cursor would silently skip that stargazer, because
+    # `after` is exclusive.
+    cursor = start_cursor
     all_edges = []
     page_count = 0
 
     query = """
-    query($cursor: String!, $repository: String!) {
+    query($cursor: String, $repository: String!) {
         repository(owner:"autowarefoundation", name:$repository) {
             stargazers(first:100, after: $cursor) {
                 totalCount
@@ -78,18 +47,16 @@ def get_stargazers(client: GitHubGraphQLClient, repository: str, start_cursor: s
     }
     """
 
-    while cursor:
+    while True:
         print(f"Fetching page {page_count + 1} for {repository}...")
         data = client.execute_query(query, {"cursor": cursor, "repository": repository})
 
         edges = data["data"]["repository"]["stargazers"]["edges"]
+        if not edges:
+            break
         all_edges.extend(edges)
         page_count += 1
-
-        if len(edges) > 0:
-            cursor = edges[-1]["cursor"]
-        else:
-            cursor = None
+        cursor = edges[-1]["cursor"]
 
     print(f"Retrieved {len(all_edges)} stargazers for {repository}")
     return all_edges

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,121 @@
+"""Tests that pagination starts at the very first item.
+
+Regression: each fetcher used to fetch ``X(first:1)``, take that first item's
+cursor, and then paginate with ``after: <that cursor>``. Because ``after`` is
+exclusive, the first stargazer / commit / issue of every repository was never
+collected, undercounting every series by exactly one.
+"""
+import get_commits
+import get_contributors
+import get_stargazers
+
+
+class FakeClient:
+    """Returns the queued pages and records the variables of each call."""
+
+    def __init__(self, pages, wrap):
+        self.pages = list(pages)
+        self.wrap = wrap
+        self.calls = []
+
+    def execute_query(self, query, variables):
+        self.calls.append(variables)
+        edges = self.pages.pop(0) if self.pages else []
+        return self.wrap(edges)
+
+
+def star_edge(login, cursor):
+    return {"cursor": cursor, "starredAt": "2024-01-01T00:00:00Z",
+            "node": {"name": None, "login": login}}
+
+
+def wrap_stargazers(edges):
+    return {"data": {"repository": {"stargazers": {"totalCount": len(edges), "edges": edges}}}}
+
+
+def wrap_commits(edges):
+    return {"data": {"repository": {"defaultBranchRef": {"target": {"history": {"edges": edges}}}}}}
+
+
+def wrap_issues(edges):
+    return {"data": {"repository": {"issues": {"totalCount": len(edges), "edges": edges}}}}
+
+
+# --- stargazers -------------------------------------------------------------
+
+def test_full_fetch_includes_the_first_stargazer():
+    client = FakeClient([[star_edge("first", "c1"), star_edge("second", "c2")], []], wrap_stargazers)
+
+    result = get_stargazers.get_stargazers(client, "repo")
+
+    assert [e["node"]["login"] for e in result] == ["first", "second"]
+    # Starts at the beginning rather than after the first stargazer's cursor.
+    assert client.calls[0]["cursor"] is None
+
+
+def test_stargazers_paginate_across_pages():
+    client = FakeClient(
+        [[star_edge("a", "c1")], [star_edge("b", "c2")], []], wrap_stargazers
+    )
+
+    result = get_stargazers.get_stargazers(client, "repo")
+
+    assert [e["node"]["login"] for e in result] == ["a", "b"]
+    assert [c["cursor"] for c in client.calls] == [None, "c1", "c2"]
+
+
+def test_stargazers_incremental_resumes_from_cursor():
+    client = FakeClient([[star_edge("new", "c9")], []], wrap_stargazers)
+
+    get_stargazers.get_stargazers(client, "repo", start_cursor="cached-cursor")
+
+    assert client.calls[0]["cursor"] == "cached-cursor"
+
+
+def test_repository_without_stargazers_returns_empty():
+    client = FakeClient([[]], wrap_stargazers)
+
+    assert get_stargazers.get_stargazers(client, "repo") == []
+    assert len(client.calls) == 1
+
+
+# --- commits ----------------------------------------------------------------
+
+def test_full_fetch_includes_the_first_commit():
+    client = FakeClient(
+        [[{"cursor": "c1", "node": {"oid": "aaa"}}, {"cursor": "c2", "node": {"oid": "bbb"}}], []],
+        wrap_commits,
+    )
+
+    result = get_commits.get_commits(client, "repo")
+
+    assert [e["node"]["oid"] for e in result] == ["aaa", "bbb"]
+    assert client.calls[0]["cursor"] is None
+
+
+def test_commits_without_default_branch_returns_empty():
+    client = FakeClient([[]], lambda edges: {"data": {"repository": {"defaultBranchRef": None}}})
+
+    assert get_commits.get_commits(client, "repo") == []
+
+
+# --- contributors -----------------------------------------------------------
+
+def test_full_fetch_includes_the_first_contributor_item():
+    client = FakeClient(
+        [[{"cursor": "c1", "node": {"title": "one"}}, {"cursor": "c2", "node": {"title": "two"}}], []],
+        wrap_issues,
+    )
+
+    result = get_contributors.get_contributors(client, "issues", "repo")
+
+    assert [e["node"]["title"] for e in result] == ["one", "two"]
+    assert client.calls[0]["cursor"] is None
+
+
+def test_contributors_incremental_resumes_from_cursor():
+    client = FakeClient([[{"cursor": "c9", "node": {"title": "new"}}], []], wrap_issues)
+
+    get_contributors.get_contributors(client, "issues", "repo", start_cursor="cached-cursor")
+
+    assert client.calls[0]["cursor"] == "cached-cursor"


### PR DESCRIPTION
Stacked on #19 — review that one first. The base will become `main` once #19 merges.

## Problem

Every fetcher seeded pagination the same way: request `X(first:1)`, take that first item's cursor, then paginate with `after: <that cursor>`. GraphQL's `after` is **exclusive**, so the first stargazer, the first commit and the first issue/PR of every repository were never collected. Every series was undercounted by exactly one, in `get_stargazers.py`, `get_commits.py` and `get_contributors.py` alike.

This was found while checking whether the recently published star numbers were correct. Comparing the published per-repo counts against GitHub's own `stargazerCount` showed a systematic **-1** on nearly every repository:

| repo | published | GitHub |
|---|---|---|
| autoware_cmake | 1 | 2 |
| autoware_internal_msgs | 1 | 2 |
| autoware_adapi_msgs | 6 | 7 |
| autoware_launch | 56 | 57 |
| AWSIM | 726 | 727 |

Summed across the tracked repositories the published data was **-28** versus reality — and the same off-by-one silently applied to commits and contributors too.

Demonstrated directly against the API on `autoware_cmake` (2 stars):

```
current algorithm : ["kmorrow1"]                 # 1 — jesseyWang skipped
after: null       : ["jesseyWang", "kmorrow1"]   # 2 — correct
```

## Fix

Paginate from the beginning rather than from the first item's cursor: declare the cursor variable as the nullable `String` instead of `String!` and pass `null` for the first page, which GraphQL interprets as "start at the first item". `get_first_cursor` becomes dead code and is removed from all three fetchers, which also saves one API round trip per repository (and per contributor type).

The page loop now terminates on an empty page rather than on a falsy cursor, because for a full fetch the starting cursor is legitimately `None`.

Incremental fetching is unchanged: a cached cursor is still passed straight through as `after`, which is correct there — resuming after the last cached item is exactly what is wanted.

## Verification

`python3 -m pytest tests/` → 25 passing, including new `tests/test_pagination.py` covering all three fetchers: the first item is included, the first request starts at `cursor=None`, multi-page pagination walks cursors correctly, incremental mode still resumes from the cached cursor, and empty repositories return empty.

End-to-end against the live API, matching GitHub exactly and recovering the previously missing first stargazer in each case:

```
autoware_cmake         fetched=2 github=2 OK  ['jesseyWang', 'kmorrow1']
autoware_internal_msgs fetched=2 github=2 OK  ['Omni-Engineering', 'kmorrow1']
autoware_adapi_msgs    fetched=7 github=7 OK  ['rorypeck', 'Omni-Engineering', 'youtalk', ...]
```

## Note on published numbers

Counts will tick up slightly once this lands, because the missing first item is finally counted. That is a correction, not inflation. Note this interacts with the regression guard added in #19 only in the harmless direction (growth is never flagged).