### PR TITLE
fix: stop a repo without star history from blanking the dashboard

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -130,6 +130,9 @@ function getRepoStarsSorted(json) {
 }
 
 function mapToChartData(dataArray, valueKey) {
+  // A missing series must degrade to an empty line, never throw: this function
+  // runs inside chart builders, and one throw there blanks the whole page.
+  if (!Array.isArray(dataArray)) return [];
   return dataArray.map((item) => [new Date(item.date), item[valueKey]]);
 }
 
@@ -303,12 +306,18 @@ function renderStarsChart(json) {
     },
   ];
 
-  getRepoStarsSorted(json).forEach(({ repo }, index) => {
-    series.push({
-      name: `${rankPrefix(index + 1)} ${repo}`,
-      data: mapToChartData(json[`${repo}_stars_history`], 'star_count'),
+  getRepoStarsSorted(json)
+    // Only repositories with an actual history series can be plotted. Some are
+    // known only by their current count, because GitHub cannot enumerate their
+    // stargazers (see CLAUDE.md). Those still appear in the Top Repositories
+    // ranking, but there is no series to draw for them here.
+    .filter(({ repo }) => Array.isArray(json[`${repo}_stars_history`]))
+    .forEach(({ repo }, index) => {
+      series.push({
+        name: `${rankPrefix(index + 1)} ${repo}`,
+        data: mapToChartData(json[`${repo}_stars_history`], 'star_count'),
+      });
     });
-  });
 
   const options = createChartOptions({
     series,
@@ -1122,34 +1131,55 @@ const [
 ]);
 
 // 3. Render each independently (error per section)
+//
+// `allSettled` above only isolates *fetch* failures. A render that throws would
+// still abort every section after it and leave the page blank, so each section
+// is wrapped too — the isolation this comment promises has to cover both.
+function safeRender(label, selector, render) {
+  try {
+    render();
+  } catch (e) {
+    console.error(`Failed to render ${label}:`, e);
+    if (selector) showError(selector, `${label} could not be rendered`);
+  }
+}
+
 if (starsResult.status === 'fulfilled') {
-  renderStarsChart(starsResult.value);
-  renderStarsYearlyChart(starsResult.value);
-  renderStarsStats(starsResult.value);
+  safeRender('Stars', '#stars-chart', () => {
+    renderStarsChart(starsResult.value);
+    renderStarsYearlyChart(starsResult.value);
+    renderStarsStats(starsResult.value);
+  });
 } else {
   showError('#stars-chart', 'Stars history data not available');
   showError('#stars-yearly-chart', 'Stars history data not available');
 }
 
 if (contributorsResult.status === 'fulfilled') {
-  renderContributorsChart(contributorsResult.value);
-  renderContributorsStats(contributorsResult.value);
+  safeRender('Contributors', '#contributors-chart', () => {
+    renderContributorsChart(contributorsResult.value);
+    renderContributorsStats(contributorsResult.value);
+  });
 } else {
   showError('#contributors-chart', 'Contributor history data not available');
 }
 
 if (downloadsResult.status === 'fulfilled') {
-  renderDownloadsChart(downloadsResult.value);
-  renderDownloadsRanking(downloadsResult.value);
-  renderDownloadsStats(downloadsResult.value);
+  safeRender('APT downloads', '#downloads-chart', () => {
+    renderDownloadsChart(downloadsResult.value);
+    renderDownloadsRanking(downloadsResult.value);
+    renderDownloadsStats(downloadsResult.value);
+  });
 } else {
   showError('#downloads-chart', 'APT download data not available');
 }
 
 if (commitsResult.status === 'fulfilled') {
   const activityData = activityResult.status === 'fulfilled' ? activityResult.value : null;
-  renderCommitsChart(commitsResult.value, activityData);
-  renderCommitsStats(commitsResult.value, activityData);
+  safeRender('Activity', '#commits-chart', () => {
+    renderCommitsChart(commitsResult.value, activityData);
+    renderCommitsStats(commitsResult.value, activityData);
+  });
 } else {
   showError('#commits-chart', 'Commit history data not available');
 }
@@ -1159,16 +1189,16 @@ const arxivCitations = arxivCitationsResult.status === 'fulfilled' ? arxivCitati
 const googleTrends = googleTrendsResult.status === 'fulfilled' ? googleTrendsResult.value : null;
 
 if (arxivMentions) {
-  renderArxivMentionsChart(arxivMentions);
+  safeRender('arXiv mentions', '#arxiv-mentions-chart', () => renderArxivMentionsChart(arxivMentions));
 } else {
   showError('#arxiv-mentions-chart', 'arXiv mentions data not available');
 }
 if (googleTrends) {
-  renderGoogleTrendsChart(googleTrends);
+  safeRender('Google Trends', '#google-trends-chart', () => renderGoogleTrendsChart(googleTrends));
 } else {
   showError('#google-trends-chart', 'Google Trends data not available');
 }
-renderVisibilityStats(arxivMentions, arxivCitations, googleTrends);
+safeRender('Visibility stats', null, () => renderVisibilityStats(arxivMentions, arxivCitations, googleTrends));
 
 if (rankingsResult.status === 'fulfilled') {
   rankingsData = rankingsResult.value;


### PR DESCRIPTION
Hotfix — the deployed dashboard currently renders empty. I introduced this in #21; sorry.

## What broke

#21 made `getRepoStarsSorted` include repositories known only by their current `stargazerCount`, so the Top Repositories ranking would finally cover the 16 whose stargazer list GitHub cannot enumerate. But `renderStarsChart` iterates that same list and looks up `json[`${repo}_stars_history`]` for each entry — undefined for exactly those 16:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'map')
    at mapToChartData (main.js:133:20)
    at renderStarsChart (main.js:306:28)
```

The throw escaped the top-level render sequence and aborted **every section after it**, so the entire page came up blank rather than just the stars chart.

Confirmed against the live payload: 37 repositories in `current_star_counts`, 21 with a `_stars_history` series, and the 16 without one are precisely the repositories that crash the chart.

## Fixes, narrowest first

- **`renderStarsChart` only plots repositories that have a history series.** The ranking still lists all 37 — that was the point of #21, and it is preserved.
- **`mapToChartData` returns `[]` for a non-array** instead of throwing. It runs inside chart builders where a throw blanks the page, so it has to degrade rather than explode.
- **Each section's render is wrapped.** `allSettled` only isolated *fetch* failures, even though the comment above it promised per-section isolation; now that promise holds for render errors too, so a future bug in one chart can't take the page down again.

## Verification

I could not execute-verify the JavaScript: there is no Node/Deno/JS parser available in this environment, so **this needs a browser check after deploy**.

What I did verify — replaying the fixed selection logic in Python over the actually-deployed `stars_history.json`:

```
Top Repositories ranking entries : 37   (unchanged; vision_pilot 710 is 4th, autoware_ai_perception 425 is 5th)
Charted series                   : 21   (only repositories with a history array)
Repos reaching mapToChartData with undefined : NONE
```

I also compared delimiter balance against the known-working `origin/main` version of the file: identical result, so the edit introduces no structural change. That is a weak check, hence the browser-check request above.

## Follow-up worth considering

This class of bug — a JS change that only fails at runtime, on real data, with no way to catch it before deploy — is unguarded in this repo. A minimal Node-based smoke test that loads `main.js` against a sample payload would have caught it. Happy to add that separately if you want it.