### PR TITLE
feat: handle GitHub's stargazer-listing restriction and explain it on the page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,23 +261,30 @@ When using `--use-cache`, fetcher scripts:
 
 ### Non-obvious Behaviors
 
-- **Some repos' `stargazers` connection is broken server-side**: for a subset of
-  repositories (`vision_pilot`, `agnocast`, `alpamayo-autoware`, `auto_e2e`,
-  `callback_isolated_executor`, and all `autoware_ai_*`), GitHub returns
-  `Something went wrong while executing your query` for *any* `stargazers(...)`
-  query — even `totalCount` alone — and REST `/repos/{o}/{r}/stargazers` returns
-  404. The scalar `stargazerCount` and REST `stargazers_count` still work. This
-  is deterministic and reproducible, **not** transient, so retrying cannot fix
-  it; these repos rely entirely on their cached stargazer data. This is why the
-  cache must never be discarded (see "Full re-fetch mode" above).
-  As a partial mitigation `get_stargazers.py` records the scalar
-  `stargazerCount` for every repository into
-  `cache/raw_stargazer_data/current_counts.json`, which
-  `calculate_stargazers_history.py` exposes as `current_star_counts` /
-  `total_current_stars`. That keeps an accurate *current* number for these
-  repos, but their per-date history cannot be rebuilt. These counts are
-  deliberately **not** added to `total_stars_history`: that series counts
-  unique *people*, and a bare count carries no identities to deduplicate by.
+- **Listing stargazers requires collaborator access**: GitHub
+  [restricted stargazer listing to admins and collaborators](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/).
+  Measured across all 37 tracked repositories with **zero exceptions**: a token
+  with `push` (WRITE/MAINTAIN/ADMIN) can list stargazers; READ/NONE cannot.
+  Unauthenticated requests get `401`, non-collaborators get REST `404` and a
+  GraphQL `Something went wrong while executing your query` — with HTTP 200 and
+  **no error type**, so it is indistinguishable from a genuine transient error
+  after the fact. `viewerPermission` is therefore the only reliable signal and
+  must be checked **before** attempting the listing; `get_stargazers.py` does
+  this via `can_list_stargazers()` and skips restricted repositories outright,
+  which also avoids burning a full retry/backoff cycle per repository.
+  The scalar `stargazerCount` is unaffected, so `get_stargazers.py` records it
+  for every repository into `cache/raw_stargazer_data/current_counts.json`
+  (exposed as `current_star_counts` / `total_current_stars`), plus per-repo
+  permission in `access_status.json` (exposed as `stargazer_access`, which the
+  dashboard uses to explain the gap). Those counts are deliberately **not**
+  added to `total_stars_history`: that series counts unique *people*, and a
+  bare count carries no identities to deduplicate by.
+  Consequences: affected repositories keep an accurate current count but their
+  per-date history **cannot be rebuilt**, and whatever history is already
+  cached is irreplaceable — which is why the cache must never be discarded (see
+  "Full re-fetch mode" above). Granting the CI token's identity write access to
+  a repository restores full history for it; changing the token's *scopes* does
+  nothing, since this is about the identity's permission on each repository.
 - **Discussions are special-cased**: Only the `autoware` repo's discussions are fetched (hardcoded in `get_contributors.py`), not all repos.
 - **Comments/reviews capped at 100 per item**: GraphQL queries use `first:100` for comments and reviews — items with more will be truncated.
 - **`repositories.py` fails silently**: If `public/repositories.json` doesn't exist at import time, `REPOSITORIES` becomes an empty list with only a printed warning. Scripts will process zero repos.

--- a/public/index.html
+++ b/public/index.html
@@ -84,6 +84,7 @@
           <div class="skeleton skeleton-card"></div>
           <div class="skeleton skeleton-card"></div>
         </div>
+        <div id="stars-note"></div>
         <div id="stars-chart" class="chart-wrapper">
           <div class="skeleton skeleton-chart"></div>
         </div>

--- a/public/main.js
+++ b/public/main.js
@@ -346,20 +346,60 @@ function renderStarsYearlyChart(json) {
   new ApexCharts(chartEl, options).render();
 }
 
+function renderStarsAccessNote(json) {
+  const el = document.querySelector('#stars-note');
+  if (!el) return;
+
+  // Driven entirely by what the last run could actually read, so the note
+  // disappears on its own if access is restored.
+  const access = json.stargazer_access;
+  const restricted = access?.restricted_repos || [];
+  if (!restricted.length) {
+    el.innerHTML = '';
+    return;
+  }
+
+  const names = restricted
+    .map(repo => `<a href="https://github.com/autowarefoundation/${repo}" target="_blank" rel="noopener noreferrer">${repo}</a>`)
+    .join(', ');
+
+  el.innerHTML = `
+    <div class="section-note">
+      <strong>Star history is unavailable for ${restricted.length} of
+      ${access.tracked_repo_count} repositories.</strong>
+      GitHub now
+      <a href="${access.reference}" target="_blank" rel="noopener noreferrer">restricts
+      listing a repository's stargazers</a> to its collaborators, so the dates
+      behind those stars can no longer be read. Their current totals are still
+      counted in <em>Total Stars</em> and in the ranking below, but they have no
+      line on the chart and are not part of <em>Total Unique Stars</em>.
+      <div class="section-note-repos">${names}</div>
+    </div>
+  `;
+}
+
 function renderStarsStats(json) {
   const latestEntry = getLastEntry(json.total_stars_history);
   const date = latestEntry ? formatDate(latestEntry.date) : 'N/A';
 
   const cards = [];
 
-  cards.push(createMetricCard('Total Unique Stars', latestEntry?.star_count || 0, 'cyan', `Unique people, updated ${date}`));
+  // The two totals cover different repository sets, so each says which.
+  const access = json.stargazer_access;
+  const uniqueScope = access
+    ? `Unique people across ${access.history_repo_count} repositories`
+    : 'Unique people';
+  cards.push(createMetricCard('Total Unique Stars', latestEntry?.star_count || 0, 'cyan',
+    `${uniqueScope}, updated ${date}`));
 
   // Sum of per-repository counts. Higher than the unique figure because one
   // person starring several repositories is counted once per repository, and
   // it also includes repositories whose stargazer list cannot be enumerated.
   if (Number.isFinite(json.total_current_stars)) {
-    cards.push(createMetricCard('Total Stars', json.total_current_stars, 'gold',
-      'Sum across repositories'));
+    const totalScope = access
+      ? `Sum across all ${access.tracked_repo_count} repositories`
+      : 'Sum across repositories';
+    cards.push(createMetricCard('Total Stars', json.total_current_stars, 'gold', totalScope));
   }
 
   // Top repos card
@@ -1149,6 +1189,7 @@ if (starsResult.status === 'fulfilled') {
     renderStarsChart(starsResult.value);
     renderStarsYearlyChart(starsResult.value);
     renderStarsStats(starsResult.value);
+    renderStarsAccessNote(starsResult.value);
   });
 } else {
   showError('#stars-chart', 'Stars history data not available');

--- a/public/style.css
+++ b/public/style.css
@@ -424,6 +424,41 @@ a:hover {
   transition: background-color 0.3s, border-color 0.3s;
 }
 
+/* Explains a caveat about the data above it. Colours come from the theme
+   variables, so it follows light/dark without a separate dark rule. */
+.section-note {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-left: 3px solid var(--accent-gold);
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 24px;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.section-note strong {
+  color: var(--text-primary);
+}
+
+.section-note a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+}
+
+.section-note a:hover {
+  text-decoration: underline;
+}
+
+.section-note-repos {
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  word-break: break-word;
+}
+
 /* =============================================================================
    Loading Skeleton
    ============================================================================= */

--- a/scripts/calculate_stargazers_history.py
+++ b/scripts/calculate_stargazers_history.py
@@ -6,6 +6,36 @@ from repositories import REPOSITORIES
 from utils import parse_github_datetime, load_json_file, generate_cumulative_history, write_json_output
 
 
+ACCESS_STATUS_FILE = "cache/raw_stargazer_data/access_status.json"
+ACCESS_RESTRICTION_URL = (
+    "https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-"
+    "to-public-api-endpoints-and-ui-views/"
+)
+
+
+def build_access_metadata(access_status: Dict, history_repos: set) -> Dict:
+    """Summarise which repositories GitHub let us list stargazers for.
+
+    Returned verbatim to the dashboard so the page can explain, from the data
+    itself, why some repositories have a current star count but no history.
+    Returns None when nothing is known, so an older cache simply shows no note.
+    """
+    if not access_status:
+        return None
+
+    restricted = sorted(
+        repo for repo, s in access_status.items()
+        if not s.get("can_list_stargazers", True)
+    )
+    return {
+        "restricted_repos": restricted,
+        "restricted_repo_count": len(restricted),
+        "history_repo_count": len(history_repos),
+        "tracked_repo_count": len(access_status),
+        "reference": ACCESS_RESTRICTION_URL,
+    }
+
+
 class StarsHistoryAnalyzer:
     """Class to analyze and generate star history from stargazer data"""
 
@@ -68,6 +98,8 @@ def main():
     all_stargazers_info = []  # Raw stargazer data for unique counting
     output_data = {}
 
+    history_repos = set()
+
     for repository in repositories:
         file_path = Path("cache/raw_stargazer_data") / f"{repository}_stargazers.json"
 
@@ -76,6 +108,7 @@ def main():
 
         if not stargazers_data:
             continue
+        history_repos.add(repository)
 
         # Extract raw stargazer info (username, date)
         stargazers_info = analyzer.extract_stargazers_info(stargazers_data)
@@ -103,6 +136,16 @@ def main():
         output_data["total_current_stars"] = sum(counts.values())
         print(f"Current star counts: {len(counts)} repositories, "
               f"{sum(counts.values())} stars total (sum, not unique)")
+
+    # Why some repositories have a count but no history, carried with the data
+    # so the dashboard can say so without hardcoding today's repository list.
+    access_meta = build_access_metadata(load_json_file(ACCESS_STATUS_FILE), history_repos)
+    if access_meta:
+        output_data["stargazer_access"] = access_meta
+        if access_meta["restricted_repos"]:
+            print(f"Stargazer listing restricted for "
+                  f"{access_meta['restricted_repo_count']} repositories: "
+                  f"{', '.join(access_meta['restricted_repos'])}")
 
     # Calculate unique stargazer count
     unique_count = len(set(

--- a/scripts/get_stargazers.py
+++ b/scripts/get_stargazers.py
@@ -7,26 +7,58 @@ from github_client import GitHubGraphQLClient, fetch_with_cache, dump_json, load
 
 CACHE_DIR = "cache/raw_stargazer_data"
 COUNTS_FILE = "current_counts.json"
+ACCESS_FILE = "access_status.json"
+
+# Permission levels whose holders GitHub still lets list stargazers. Measured
+# across all tracked repositories with no exceptions: WRITE and above works,
+# READ/TRIAGE/NONE does not. See ACCESS_RESTRICTION_URL.
+LISTING_PERMISSIONS = {"ADMIN", "MAINTAIN", "WRITE"}
+RESTRICTED_PERMISSIONS = {"TRIAGE", "READ", "NONE"}
+ACCESS_RESTRICTION_URL = (
+    "https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-"
+    "to-public-api-endpoints-and-ui-views/"
+)
 
 
-def get_stargazer_count(client: GitHubGraphQLClient, repository: str) -> int:
-    """Current star count for a repository.
+def can_list_stargazers(viewer_permission: str) -> bool:
+    """Whether the authenticated token may list this repository's stargazers.
 
-    Uses the scalar `stargazerCount` rather than the `stargazers` connection.
-    GitHub fails every `stargazers(...)` query for some repositories (see
-    "Non-obvious Behaviors" in CLAUDE.md) but still reports this scalar
-    correctly, so those repositories at least keep an accurate current number
-    even though their per-date history cannot be rebuilt.
+    GitHub restricted stargazer listing to admins and collaborators. The
+    refusal arrives as a generic "Something went wrong" message with HTTP 200
+    and no error type, so it cannot be recognised after the fact — checking the
+    permission up front is what keeps us from burning a full retry/backoff
+    cycle on a request that can never succeed.
+
+    Unknown levels are treated as allowed so that a future permission name does
+    not silently drop a repository we can actually read.
+    """
+    if not viewer_permission:
+        return False
+    return viewer_permission.upper() not in RESTRICTED_PERMISSIONS
+
+
+def get_repository_star_info(client: GitHubGraphQLClient, repository: str) -> Dict:
+    """Current star count and the token's permission on a repository.
+
+    Deliberately uses the scalar `stargazerCount`, never the `stargazers`
+    connection: the scalar still works for repositories whose stargazer list
+    the token may not read, so every repository keeps an accurate current
+    number even when its per-date history cannot be built.
     """
     query = """
     query($repository: String!) {
         repository(owner:"autowarefoundation", name:$repository) {
             stargazerCount
+            viewerPermission
         }
     }
     """
     data = client.execute_query(query, {"repository": repository})
-    return data["data"]["repository"]["stargazerCount"]
+    repo = data["data"]["repository"]
+    return {
+        "stargazerCount": repo["stargazerCount"],
+        "viewerPermission": repo.get("viewerPermission"),
+    }
 
 
 def get_stargazers(client: GitHubGraphQLClient, repository: str, start_cursor: str = None) -> List[Dict]:
@@ -92,15 +124,65 @@ def get_usernames(stargazers: List[Dict]) -> Set[str]:
     return usernames
 
 
-def dump_usernames(usernames: Set[str], filename: str, output_dir: str = CACHE_DIR):
+def dump_usernames(usernames: Set[str], filename: str, output_dir: str = None):
     """Write usernames to a file"""
-    output_path = Path(output_dir)
+    # Resolved at call time, not bound as a default: a default argument would
+    # capture CACHE_DIR at import and ignore any later override.
+    output_path = Path(output_dir if output_dir is not None else CACHE_DIR)
     output_path.mkdir(exist_ok=True, parents=True)
     file_path = output_path / filename
     with open(file_path, 'w') as f:
         for username in sorted(usernames):
             f.write(f"{username}\n")
     print(f"Saved {filename} to {file_path}")
+
+
+def process_repository(client: GitHubGraphQLClient, repository: str,
+                       use_cache: bool, status: Dict) -> Set[str]:
+    """Fetch one repository's stargazers, recording what was possible.
+
+    Returns the usernames collected (empty when the listing is restricted or
+    fails). Never raises: one repository must not end the run.
+    """
+    try:
+        info = get_repository_star_info(client, repository)
+    except Exception as e:
+        print(f"Could not read star info for {repository}: {e}")
+        return set()
+
+    permission = info["viewerPermission"]
+    allowed = can_list_stargazers(permission)
+    status[repository] = {
+        "stars": info["stargazerCount"],
+        "viewer_permission": permission,
+        "can_list_stargazers": allowed,
+        "listing_failed": False,
+    }
+
+    if not allowed:
+        # Skipping rather than trying: the request is guaranteed to fail, and
+        # attempting it would cost a full retry/backoff cycle per repository.
+        print(f"Skipping stargazer listing for {repository}: "
+              f"not permitted with {permission} permission")
+        return set()
+
+    try:
+        data = fetch_with_cache(
+            repository + "_stargazers.json",
+            CACHE_DIR,
+            lambda start_cursor=None, r=repository: get_stargazers(client, r, start_cursor=start_cursor),
+            use_cache=use_cache,
+        )
+    except Exception as e:
+        print(f"Error processing {repository}: {e}")
+        status[repository]["listing_failed"] = True
+        return set()
+
+    if not data:
+        return set()
+    usernames = get_usernames(data)
+    dump_usernames(usernames, repository + "_usernames.txt")
+    return usernames
 
 
 def main():
@@ -130,44 +212,41 @@ def main():
 
     all_usernames = set()
 
-    # Keep previously recorded counts so a transient failure does not erase one.
+    # Keep previously recorded values so a transient failure does not erase one.
     cached_counts = load_cache(COUNTS_FILE, CACHE_DIR)
     current_counts = cached_counts if isinstance(cached_counts, dict) else {}
+    cached_status = load_cache(ACCESS_FILE, CACHE_DIR)
+    access_status = cached_status if isinstance(cached_status, dict) else {}
 
     for repository in repositories:
-        # Recorded before the edge fetch, and separately from it: this scalar
-        # still works for repositories whose stargazers connection is broken,
-        # which are exactly the ones the fetch below will fail on.
-        try:
-            current_counts[repository] = get_stargazer_count(client, repository)
-        except Exception as e:
-            print(f"Could not read stargazerCount for {repository}: {e}")
-
-        try:
-            cache_file = repository + "_stargazers.json"
-            data = fetch_with_cache(
-                cache_file,
-                CACHE_DIR,
-                lambda start_cursor=None, r=repository: get_stargazers(client, r, start_cursor=start_cursor),
-                use_cache=args.use_cache,
-            )
-            if data:
-                usernames = get_usernames(data)
-                dump_usernames(usernames, repository + "_usernames.txt")
-                all_usernames.update(usernames)
-        except Exception as e:
-            print(f"Error processing {repository}: {e}")
-            continue
+        status = {}
+        all_usernames.update(
+            process_repository(client, repository, args.use_cache, status)
+        )
+        if repository in status:
+            access_status[repository] = status[repository]
+            current_counts[repository] = status[repository]["stars"]
 
     # Save aggregated usernames
     dump_usernames(all_usernames, "usernames.txt")
     dump_json(current_counts, COUNTS_FILE, CACHE_DIR)
+    dump_json(access_status, ACCESS_FILE, CACHE_DIR)
+
+    restricted = sorted(
+        r for r, s in access_status.items() if not s.get("can_list_stargazers", True)
+    )
 
     print("\n" + "="*60)
     print(f"Retrieved stargazers from {len(repositories)} repositories")
     print(f"Total unique stargazers: {len(all_usernames)}")
     print(f"Current star counts recorded: {len(current_counts)} repositories "
           f"({sum(current_counts.values())} stars total)")
+    if restricted:
+        print(f"\nStargazer listing not permitted for {len(restricted)} repositories "
+              f"(no per-date history can be built for them):")
+        for repository in restricted:
+            print(f"  - {repository} ({access_status[repository].get('viewer_permission')})")
+        print(f"See {ACCESS_RESTRICTION_URL}")
     print("="*60)
 
 if __name__ == "__main__":

--- a/tests/test_access_metadata.py
+++ b/tests/test_access_metadata.py
@@ -1,0 +1,53 @@
+"""Tests for the access metadata published alongside star history.
+
+The dashboard has to explain why some repositories have a current star count
+but no history line, so the reason has to travel with the data rather than be
+hardcoded in the page. It is derived from what actually happened in the run,
+which means it disappears by itself if the token later gains access.
+"""
+import calculate_stargazers_history as calc
+
+
+def status(permission, can_list, stars=10, failed=False):
+    return {"stars": stars, "viewer_permission": permission,
+            "can_list_stargazers": can_list, "listing_failed": failed}
+
+
+def test_restricted_repos_are_reported():
+    access = {
+        "autoware": status("MAINTAIN", True),
+        "vision_pilot": status("READ", False, stars=714),
+        "agnocast": status("READ", False, stars=194),
+    }
+
+    meta = calc.build_access_metadata(access, history_repos={"autoware"})
+
+    assert meta["restricted_repos"] == ["agnocast", "vision_pilot"]
+    assert meta["restricted_repo_count"] == 2
+    assert meta["history_repo_count"] == 1
+    assert meta["tracked_repo_count"] == 3
+    assert "github.blog" in meta["reference"]
+
+
+def test_no_restrictions_reports_none():
+    access = {"autoware": status("MAINTAIN", True), "AWSIM": status("WRITE", True)}
+
+    meta = calc.build_access_metadata(access, history_repos={"autoware", "AWSIM"})
+
+    assert meta["restricted_repos"] == []
+    assert meta["restricted_repo_count"] == 0
+
+
+def test_a_permitted_repo_that_failed_is_not_called_restricted():
+    """A failed fetch is a different problem from being denied access."""
+    access = {"autoware": status("MAINTAIN", True, failed=True)}
+
+    meta = calc.build_access_metadata(access, history_repos=set())
+
+    assert meta["restricted_repos"] == []
+
+
+def test_missing_access_status_yields_no_metadata():
+    """Older caches have no access file; the page must simply show no notice."""
+    assert calc.build_access_metadata({}, history_repos={"autoware"}) is None
+    assert calc.build_access_metadata(None, history_repos={"autoware"}) is None

--- a/tests/test_current_star_counts.py
+++ b/tests/test_current_star_counts.py
@@ -6,47 +6,11 @@ accurate current number for those repositories even though their per-date
 history cannot be rebuilt.
 """
 import check_regression as cr
-import get_stargazers
 
+# Reading the scalar count is covered by tests/test_stargazer_access.py, which
+# owns the restricted-listing behaviour it is paired with.
 
-class CountClient:
-    """Answers stargazerCount queries; optionally fails for some repositories."""
-
-    def __init__(self, counts, broken=()):
-        self.counts = counts
-        self.broken = set(broken)
-        self.queried = []
-
-    def execute_query(self, query, variables):
-        repo = variables["repository"]
-        self.queried.append(repo)
-        if repo in self.broken:
-            raise Exception("GraphQL errors: ['Something went wrong ...']")
-        return {"data": {"repository": {"stargazerCount": self.counts[repo]}}}
-
-
-def test_reads_the_scalar_count():
-    client = CountClient({"vision_pilot": 710})
-
-    assert get_stargazers.get_stargazer_count(client, "vision_pilot") == 710
-
-
-def test_count_query_does_not_use_the_stargazers_connection():
-    """The whole point: avoid the connection that is broken for these repos."""
-    captured = {}
-
-    class Recorder:
-        def execute_query(self, query, variables):
-            captured["query"] = query
-            return {"data": {"repository": {"stargazerCount": 1}}}
-
-    get_stargazers.get_stargazer_count(Recorder(), "repo")
-
-    assert "stargazerCount" in captured["query"]
-    assert "stargazers(" not in captured["query"]
-
-
-# --- regression guard coverage of the new metrics ---------------------------
+# --- regression guard coverage of the current-count metrics -----------------
 
 def _stars(counts_map, total):
     return {

--- a/tests/test_stargazer_access.py
+++ b/tests/test_stargazer_access.py
@@ -1,0 +1,150 @@
+"""Tests for handling GitHub's stargazer-listing access restriction.
+
+GitHub restricted `GET /repos/{o}/{r}/stargazers` and the GraphQL `stargazers`
+connection to admins and collaborators:
+https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/
+
+Measured behaviour, consistent across all 37 tracked repositories with no
+exceptions: `push` permission (WRITE/MAINTAIN/ADMIN) can list stargazers,
+READ/NONE cannot. The failure surfaces as a generic "Something went wrong"
+message with HTTP 200 and no error type, so it is indistinguishable from a
+transient error after the fact — `viewerPermission` is the only reliable
+signal, and it must be checked *before* attempting the listing.
+"""
+import get_stargazers
+
+
+class FakeClient:
+    """Serves canned responses and records every query it is asked to run."""
+
+    def __init__(self, permission="MAINTAIN", count=42, pages=None):
+        self.permission = permission
+        self.count = count
+        self.pages = list(pages or [[]])
+        self.queries = []
+
+    def execute_query(self, query, variables):
+        self.queries.append(query)
+        if "viewerPermission" in query:
+            return {"data": {"repository": {
+                "stargazerCount": self.count,
+                "viewerPermission": self.permission,
+            }}}
+        if "stargazers(" in query:
+            edges = self.pages.pop(0) if self.pages else []
+            return {"data": {"repository": {"stargazers": {
+                "totalCount": self.count, "edges": edges,
+            }}}}
+        raise AssertionError(f"unexpected query: {query}")
+
+    @property
+    def listed_stargazers(self):
+        return any("stargazers(" in q for q in self.queries)
+
+
+def star_edge(login, cursor):
+    return {"cursor": cursor, "starredAt": "2024-01-01T00:00:00Z",
+            "node": {"name": None, "login": login}}
+
+
+# --- permission rule --------------------------------------------------------
+
+def test_collaborator_permissions_can_list():
+    for perm in ("ADMIN", "MAINTAIN", "WRITE"):
+        assert get_stargazers.can_list_stargazers(perm) is True, perm
+
+
+def test_non_collaborator_permissions_cannot_list():
+    # TRIAGE has push=false, which measured as restricted alongside READ/NONE.
+    for perm in ("TRIAGE", "READ", "NONE", None, ""):
+        assert get_stargazers.can_list_stargazers(perm) is False, perm
+
+
+def test_unknown_permission_is_treated_as_allowed():
+    """A future/unseen level must not silently drop a repository we could read."""
+    assert get_stargazers.can_list_stargazers("SOMETHING_NEW") is True
+
+
+# --- info query -------------------------------------------------------------
+
+def test_info_query_avoids_the_restricted_connection():
+    client = FakeClient(permission="READ", count=714)
+
+    info = get_stargazers.get_repository_star_info(client, "vision_pilot")
+
+    assert info == {"stargazerCount": 714, "viewerPermission": "READ"}
+    # The scalar must not be fetched through the connection that is restricted.
+    assert not client.listed_stargazers
+
+
+# --- per-repository processing ---------------------------------------------
+
+def test_restricted_repo_is_not_listed_and_is_recorded():
+    client = FakeClient(permission="READ", count=714)
+    status = {}
+
+    usernames = get_stargazers.process_repository(client, "vision_pilot", False, status)
+
+    assert usernames == set()
+    # The whole point: no doomed request, so no retry/backoff storm either.
+    assert not client.listed_stargazers
+    assert status["vision_pilot"]["can_list_stargazers"] is False
+    assert status["vision_pilot"]["stars"] == 714
+    assert status["vision_pilot"]["viewer_permission"] == "READ"
+
+
+def test_permitted_repo_is_listed_and_recorded(tmp_path, monkeypatch):
+    monkeypatch.setattr(get_stargazers, "CACHE_DIR", str(tmp_path))
+    client = FakeClient(permission="MAINTAIN", count=2,
+                        pages=[[star_edge("a", "c1"), star_edge("b", "c2")], []])
+    status = {}
+
+    usernames = get_stargazers.process_repository(client, "autoware", False, status)
+
+    assert usernames == {"a", "b"}
+    assert client.listed_stargazers
+    assert status["autoware"]["can_list_stargazers"] is True
+
+
+def test_output_honours_the_configured_cache_dir(tmp_path, monkeypatch):
+    """Writes must follow CACHE_DIR, so a run cannot escape its own directory."""
+    monkeypatch.setattr(get_stargazers, "CACHE_DIR", str(tmp_path))
+    client = FakeClient(permission="ADMIN", count=1, pages=[[star_edge("a", "c1")], []])
+
+    get_stargazers.process_repository(client, "autoware", False, {})
+
+    assert (tmp_path / "autoware_usernames.txt").exists()
+
+
+def test_listing_failure_is_recorded_without_raising(tmp_path, monkeypatch):
+    """A permitted repo whose listing still fails must not abort the run."""
+    monkeypatch.setattr(get_stargazers, "CACHE_DIR", str(tmp_path))
+
+    class Failing(FakeClient):
+        def execute_query(self, query, variables):
+            if "stargazers(" in query:
+                self.queries.append(query)
+                raise Exception("GraphQL errors: ['Something went wrong ...']")
+            return super().execute_query(query, variables)
+
+    client = Failing(permission="MAINTAIN", count=5)
+    status = {}
+
+    usernames = get_stargazers.process_repository(client, "autoware", False, status)
+
+    assert usernames == set()
+    assert status["autoware"]["can_list_stargazers"] is True
+    assert status["autoware"]["listing_failed"] is True
+
+
+def test_star_count_is_recorded_even_when_permission_lookup_fails():
+    class Broken(FakeClient):
+        def execute_query(self, query, variables):
+            raise Exception("network down")
+
+    status = {}
+    usernames = get_stargazers.process_repository(Broken(), "repo", False, status)
+
+    assert usernames == set()
+    # Nothing known about the repo, but the run continues.
+    assert "repo" not in status or status["repo"].get("stars") is None


### PR DESCRIPTION
## Root cause

GitHub [restricted listing a repository's stargazers to admins and collaborators](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/). That is what has been failing.

Measured across all 37 tracked repositories, **zero exceptions**:

| access | result |
|---|---|
| unauthenticated | `401 Requires authentication` (this used to be a public endpoint) |
| collaborator (`push=true`: WRITE/MAINTAIN/ADMIN) | works |
| non-collaborator (`push=false`: READ/NONE) | REST `404`, GraphQL `Something went wrong` |

The GraphQL refusal arrives with **HTTP 200 and no error type**, so after the fact it is indistinguishable from a genuine transient error. Our retry logic classified it as transient and retried it six times with backoff — for each of the 15 affected repositories, every run, spending roughly a quarter of an hour to fail exactly as it would have immediately.

This also **corrects the previous diagnosis**: CLAUDE.md described these repositories as having a server-side defect. They do not. It is an intentional access restriction, and `viewerPermission` predicts it perfectly.

## Handling

- **Check `viewerPermission` before attempting the listing** (`can_list_stargazers`) and skip repositories that cannot be read, because the request cannot succeed. Unknown permission levels are treated as *allowed*, so a future level never silently drops a repository we could actually read.
- **Fetch `stargazerCount` + `viewerPermission` in one query.** Both work regardless of access. Recorded per repository in `access_status.json`, merged rather than replaced so a transient failure cannot erase what is known.
- **Extract `process_repository`**, which never raises: restricted, failed, or unreadable, one repository cannot end the run.
- **Fix `dump_usernames`** to resolve `CACHE_DIR` at call time. As a default argument it was captured at import, so an overridden cache directory was ignored — writes escaped into the real cache during tests.

## Explaining it on the dashboard

All of it is derived from what the run could actually read, so **the notice disappears by itself if access is ever restored** — nothing is hardcoded to today's repository list.

- `calculate_stargazers_history.py` publishes `stargazer_access`: the restricted repositories, how many have history, how many are tracked, and the changelog link.
- The Stars section gains a note naming the affected repositories, stating that their current totals still count toward **Total Stars** and the ranking, but that they have no chart line and are not part of **Total Unique Stars**.
- Both totals now state which repository set they cover, because they genuinely differ.

## About fixing this with a token instead

Worth knowing, and deliberately **not** done here: this is about the *identity's permission on each repository*, not the token's scopes — regenerating or re-scoping the current token changes nothing. Granting the CI identity write access to a repository does restore its full history, and an org-owner token would likely cover all 37. Two caveats: 8 of the 15 affected repositories are archived, so they would each need unarchive → grant → re-archive; and an org-owner PAT in a public repository's Actions secret is a broad credential to hold. Either way this change is still wanted, since it removes the wasted retries and degrades honestly if the restriction tightens again.

## Verification

`python3 -m pytest tests/` → **40 passing**, including new `tests/test_stargazer_access.py` (permission rule, the info query never touching the restricted connection, restricted repos skipped without a doomed request, failures recorded without raising, writes staying inside the configured cache dir) and `tests/test_access_metadata.py`.

End to end against the live API:

```
vision_pilot   : skipped instantly, recorded READ / can_list=false, stars=714
autoware_cmake : listed 2 stargazers, ADMIN
```

Running the calculate step over a fixture built from the real permission sweep produced the expected metadata for all 37 repositories (15 restricted).

**JavaScript is syntax-checked only.** There is no JS runtime in this environment, so browser behaviour is unverified — please confirm the Stars section after deploy. I validated syntax with a real parser (esprima) using `origin/main` as a control to prove the check itself was sound; both parse cleanly.

## Follow-up worth considering

The dashboard has no way to catch a JS error before deploy — that is exactly how #22 shipped a blank page. A small Node-based smoke test that loads `main.js` against a sample payload would close that gap. Happy to add it separately.