### PR TITLE
feat: add a skill for previewing and verifying the dashboard locally

### DIFF
--- a/.claude/skills/dashboard-preview/SKILL.md
+++ b/.claude/skills/dashboard-preview/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: dashboard-preview
+description: Run the contributor-metrics dashboard locally against the real deployed JSON and prove main.js renders without throwing. Use this whenever touching public/main.js, public/index.html, public/style.css, or the shape of anything the pipeline writes into results/*.json — including asks like "run it locally", "start a local server", "preview the page", "check the dashboard still works", "動作確認", or verifying a chart, metric card, or section before opening a PR. Use it for pipeline-side changes too: the page reads those JSON files directly, so adding, renaming, or dropping a field can blank the whole dashboard even though no front-end file changed.
+---
+
+# Previewing and verifying the dashboard
+
+The dashboard is static HTML that fetches JSON at runtime and draws everything
+client-side. Nothing about a front-end change is checked before deploy — no
+build, no type check, no test — so a wrong assumption about the data's shape
+first shows up as a blank page for real visitors.
+
+That is not hypothetical. A change once made the Top Repositories ranking
+include repositories that have a current star count but no history series. The
+chart builder iterated the same list and reached for `json[repo_stars_history]`,
+which was `undefined`, and the resulting throw escaped the top-level render
+sequence and aborted **every section after it**. The page had rendered fine in
+every earlier version, and the fetch-level error handling looked thorough — it
+just didn't cover errors thrown *during* rendering.
+
+So the goal here is to run the actual `main.js` against actual data before it
+reaches anyone. Two levels, both cheap:
+
+1. **Headless run** — catches throws, in about a second, no browser needed.
+2. **Local server** — for looking at layout, colours, and wording yourself.
+
+Do the headless run even when you plan to look at the page anyway. It reports
+the failing line and stack, which a blank browser tab does not.
+
+## 1. Get real data
+
+```bash
+.claude/skills/dashboard-preview/scripts/fetch_data.sh public
+```
+
+This downloads the ten published JSON files into `public/`. They are gitignored,
+so this never dirties a commit.
+
+Use the deployed copies rather than hand-written fixtures. They are real and
+current, and they contain the awkward shapes that actually break things —
+repositories missing from one file but present in another, empty series, fields
+that only some entries carry. Regenerating them locally is not a practical
+alternative: that needs a GitHub token and roughly an hour.
+
+## 2. Run it headless
+
+```bash
+node .claude/skills/dashboard-preview/scripts/verify_render.mjs public
+```
+
+The script evaluates `public/main.js` in a stubbed DOM with `fetch` served from
+local files and `ApexCharts` recorded rather than drawn. It exits non-zero if
+anything threw, so it also works as a pre-commit or pre-deploy gate.
+
+A healthy run names each chart and how many series it drew, plus which sections
+produced content:
+
+```
+PASS — main.js ran with no uncaught errors
+  charts rendered: 12
+    GitHub Star Growth Over Time: 22 series
+    ...
+  sections with content: 7
+    #stars-stats (3262 chars)
+```
+
+Read those numbers, don't just check for PASS. A chart that renders with zero
+series, or a stats section that never appears, is a real defect the script
+cannot call a failure — it only knows nothing threw.
+
+To inspect what a specific element received:
+
+```bash
+node .claude/skills/dashboard-preview/scripts/verify_render.mjs public --dump '#stars-note'
+```
+
+`--json` prints the whole report as JSON if you want to assert on it.
+
+### If node is missing
+
+The repo has no Node dependency, so it may not be installed. Fetch a private
+copy into the scratchpad rather than installing system-wide:
+
+```bash
+curl -sSL -o /tmp/node.tar.xz https://nodejs.org/dist/v22.11.0/node-v22.11.0-linux-x64.tar.xz
+tar -xf /tmp/node.tar.xz -C /tmp
+/tmp/node-v22.11.0-linux-x64/bin/node --version
+```
+
+Then invoke that binary by path.
+
+### What the stub does not cover
+
+It proves the code runs and what data reached each element. It says nothing
+about how any of it looks — layout, contrast, overflow, dark mode, and whether
+ApexCharts itself is happy with the options all need a browser. Say so plainly
+when reporting results; "verified" without that qualifier overstates it.
+
+## 3. Serve it for a human look
+
+```bash
+cd public && python3 -m http.server 8000 --bind 127.0.0.1
+```
+
+Then open <http://localhost:8000/index.html>. Run it in the background so the
+session stays usable, and confirm it is actually up before handing over the URL:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8000/index.html
+```
+
+Opening `index.html` as a `file://` URL does not work — the page fetches JSON by
+relative path, which needs an HTTP origin.
+
+Tell the user the URL, what you changed, and what specifically to look at.
+
+## Verifying a change the pipeline hasn't published yet
+
+Deployed data only exercises the fields that already exist. If your change adds
+or renames one, the deployed copies will silently take the fallback path and the
+new code never runs — a PASS then means very little.
+
+When that applies, write the new shape into a copy of the data and point the
+script at it, keeping `public/` untouched:
+
+```bash
+cp -r public /tmp/newdata
+# edit /tmp/newdata/<file>.json to add the new field
+node .claude/skills/dashboard-preview/scripts/verify_render.mjs public /tmp/newdata
+```
+
+Derive the synthetic values from the real data instead of inventing them, so the
+preview matches what the pipeline will actually produce. Check both paths: with
+the field, and with the deployed data that lacks it, since older cached payloads
+are served until the next successful run.
+
+## Reporting back
+
+Say which of these you did and what each showed. Distinguish "ran without
+throwing" from "looks right" — only a browser establishes the second, and if you
+could not open one, ask the user to confirm that part.

--- a/.claude/skills/dashboard-preview/scripts/fetch_data.sh
+++ b/.claude/skills/dashboard-preview/scripts/fetch_data.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Download the deployed dashboard JSON into a directory.
+#
+# The pipeline needs a GitHub token and roughly an hour to regenerate these
+# files, so for front-end work the published copies are the practical source of
+# truth: they are real, current, and include the awkward shapes that synthetic
+# fixtures tend to miss.
+#
+# Usage: fetch_data.sh [target-dir]   (default: public)
+
+set -euo pipefail
+
+TARGET="${1:-public}"
+BASE="${DASHBOARD_BASE_URL:-https://autowarefoundation.github.io/autoware-contributor-metrics}"
+
+FILES=(
+  repositories
+  stars_history
+  contributors_history
+  commits_history
+  activity_history
+  rankings
+  apt_downloads
+  arxiv_mentions_history
+  arxiv_citations_history
+  google_trends_history
+)
+
+mkdir -p "$TARGET"
+failed=0
+
+for name in "${FILES[@]}"; do
+  url="$BASE/$name.json"
+  tmp="$(mktemp)"
+  if curl -sSf --max-time 120 -o "$tmp" "$url" && python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp"; then
+    mv "$tmp" "$TARGET/$name.json"
+    printf '  %-30s %10s bytes\n' "$name.json" "$(stat -c%s "$TARGET/$name.json")"
+  else
+    rm -f "$tmp"
+    printf '  %-30s FAILED (kept existing copy if any)\n' "$name.json"
+    failed=$((failed + 1))
+  fi
+done
+
+if [ "$failed" -gt 0 ]; then
+  echo "warning: $failed file(s) could not be downloaded" >&2
+fi
+echo "data in $TARGET/"

--- a/.claude/skills/dashboard-preview/scripts/verify_render.mjs
+++ b/.claude/skills/dashboard-preview/scripts/verify_render.mjs
@@ -1,0 +1,198 @@
+// Executes the dashboard's main.js against real data in a stubbed DOM, so that
+// a render-time exception is caught here instead of on the deployed page.
+//
+// The page loads its JSON at runtime and draws everything client-side, so a bad
+// assumption about the data's shape only fails in the browser. That is how a
+// blank dashboard once shipped: one chart threw, and the throw aborted every
+// section after it. Running the same file here reproduces that in a second.
+//
+// Usage:
+//   node verify_render.mjs <public-dir> [data-dir] [--json] [--dump <selector>]
+//
+// data-dir defaults to public-dir. Exits non-zero if anything threw, so this
+// can gate a commit or a deploy.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const args = process.argv.slice(2);
+const flags = new Set(args.filter((a) => a.startsWith('--')));
+const positional = args.filter((a) => !a.startsWith('--'));
+const dumpIndex = args.indexOf('--dump');
+const dumpSelector = dumpIndex !== -1 ? args[dumpIndex + 1] : null;
+
+const publicDir = positional[0];
+const dataDir = positional[1] && positional[1] !== dumpSelector ? positional[1] : publicDir;
+
+if (!publicDir) {
+  console.error('usage: node verify_render.mjs <public-dir> [data-dir] [--json] [--dump <selector>]');
+  process.exit(2);
+}
+
+const elements = new Map();
+const charts = [];
+const errors = [];
+const consoleErrors = [];
+const domReadyListeners = [];
+
+function makeElement(name) {
+  return {
+    __name: name,
+    innerHTML: '',
+    textContent: '',
+    value: '',
+    checked: false,
+    dataset: {},
+    style: {},
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    children: [],
+    setAttribute() {}, getAttribute: () => null, removeAttribute() {},
+    addEventListener() {}, removeEventListener() {}, click() {},
+    appendChild() {}, removeChild() {}, remove() {}, insertAdjacentHTML() {},
+    closest: () => null,
+    querySelector: (s) => element(`${name} ${s}`),
+    querySelectorAll: (s) => [element(`${name} ${s}`)],
+    getBoundingClientRect: () => ({ top: 0, left: 0, width: 1200, height: 400 }),
+    scrollIntoView() {}, focus() {},
+  };
+}
+
+function element(selector) {
+  if (!elements.has(selector)) elements.set(selector, makeElement(selector));
+  return elements.get(selector);
+}
+
+const document = {
+  documentElement: makeElement(':root'),
+  body: makeElement('body'),
+  readyState: 'complete',
+  querySelector: element,
+  // One stand-in per selector: enough for the loops the page runs over nav
+  // links and sections, without pretending to know the real element count.
+  querySelectorAll: (s) => [element(s)],
+  getElementById: (id) => element(`#${id}`),
+  createElement: (tag) => makeElement(`<${tag}>`),
+  addEventListener(type, fn) {
+    if (type === 'DOMContentLoaded') domReadyListeners.push(fn);
+  },
+  removeEventListener() {},
+};
+
+class ApexCharts {
+  constructor(el, options) { this.el = el; this.options = options; charts.push(options); }
+  render() { return Promise.resolve(); }
+  updateOptions() {} updateSeries() {} destroy() {}
+}
+
+const storage = new Map();
+const localStorage = {
+  getItem: (k) => (storage.has(k) ? storage.get(k) : null),
+  setItem: (k, v) => storage.set(k, String(v)),
+  removeItem: (k) => storage.delete(k),
+};
+
+async function fetchStub(url) {
+  const file = path.join(dataDir, path.basename(String(url)));
+  if (!fs.existsSync(file)) {
+    const err = new Error(`404 ${url}`);
+    err.status = 404;
+    throw err;
+  }
+  const text = fs.readFileSync(file, 'utf8');
+  return { ok: true, status: 200, json: async () => JSON.parse(text), text: async () => text };
+}
+
+const sandboxConsole = {
+  ...console,
+  error: (...a) => { consoleErrors.push(a.map(String).join(' ')); },
+};
+
+const windowStub = {
+  innerWidth: 1400,
+  innerHeight: 900,
+  location: { href: 'http://localhost/', search: '', hash: '' },
+  addEventListener() {}, removeEventListener() {},
+  matchMedia: () => ({ matches: false, addEventListener() {}, addListener() {}, removeEventListener() {} }),
+  requestAnimationFrame: (fn) => fn(),
+  localStorage,
+  scrollTo() {},
+};
+
+// Only host objects are injected. Standard built-ins already exist inside the
+// context, and passing this realm's copies in would break instanceof checks.
+const sandbox = {
+  document,
+  window: windowStub,
+  ApexCharts,
+  fetch: fetchStub,
+  localStorage,
+  matchMedia: windowStub.matchMedia,
+  requestAnimationFrame: windowStub.requestAnimationFrame,
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} },
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  console: sandboxConsole,
+  setTimeout, clearTimeout, setInterval, clearInterval, queueMicrotask,
+};
+sandbox.globalThis = sandbox;
+sandbox.self = sandbox;
+vm.createContext(sandbox);
+
+process.on('unhandledRejection', (e) => {
+  errors.push(`unhandledRejection: ${(e && e.stack) || e}`);
+});
+
+const mainPath = path.join(publicDir, 'main.js');
+if (!fs.existsSync(mainPath)) {
+  console.error(`not found: ${mainPath}`);
+  process.exit(2);
+}
+
+try {
+  vm.runInContext(fs.readFileSync(mainPath, 'utf8'), sandbox, { filename: 'main.js' });
+  for (const fn of domReadyListeners) fn();
+} catch (e) {
+  errors.push(`threw during evaluation: ${(e && e.stack) || e}`);
+}
+
+// The page's top-level work is async, so give its promises time to settle.
+await new Promise((r) => setTimeout(r, 2000));
+
+const report = {
+  ok: errors.length === 0,
+  errors,
+  consoleErrors,
+  chartCount: charts.length,
+  chartTitles: charts.map((c) => c && c.title && c.title.text).filter(Boolean),
+  seriesPerChart: charts.map((c) => ({
+    title: (c && c.title && c.title.text) || '(untitled)',
+    series: (c && c.series ? c.series : []).map((s) => s && s.name).filter(Boolean),
+  })),
+  renderedSelectors: [...elements.entries()]
+    .filter(([, el]) => el.innerHTML)
+    .map(([selector, el]) => ({ selector, length: el.innerHTML.length })),
+};
+
+if (dumpSelector) {
+  report.dump = { selector: dumpSelector, innerHTML: elements.get(dumpSelector)?.innerHTML ?? null };
+}
+
+if (flags.has('--json')) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log(report.ok ? 'PASS — main.js ran with no uncaught errors' : 'FAIL — main.js threw');
+  for (const e of errors) console.log(`  error: ${e}`);
+  for (const e of consoleErrors) console.log(`  console.error: ${e}`);
+  console.log(`  charts rendered: ${report.chartCount}`);
+  for (const c of report.seriesPerChart) {
+    console.log(`    ${c.title}: ${c.series.length} series`);
+  }
+  console.log(`  sections with content: ${report.renderedSelectors.length}`);
+  for (const s of report.renderedSelectors) console.log(`    ${s.selector} (${s.length} chars)`);
+  if (report.dump) {
+    console.log(`\n  --- ${report.dump.selector} ---`);
+    console.log(report.dump.innerHTML === null ? '  (element never rendered)' : report.dump.innerHTML);
+  }
+}
+
+process.exit(report.ok ? 0 : 1);


### PR DESCRIPTION
Independent of #23 — branched from `main`, touches only `.claude/skills/`.

## Why

The dashboard is static HTML that fetches JSON at runtime and draws everything client-side. Nothing about a front-end change is checked before deploy — no build, no type check, no test — so a wrong assumption about the data's shape first surfaces as a blank page for real visitors.

That is how #22 shipped: one chart builder reached for a series that did not exist, and the throw escaped the top-level render sequence and aborted every section after it. The fetch-level error handling looked thorough; it just didn't cover errors thrown *during* rendering.

This packages the workflow that found and confirmed that bug so it is repeatable.

## What's in it

`.claude/skills/dashboard-preview/`

- **`scripts/fetch_data.sh`** — downloads the ten published JSON files into `public/` (gitignored, so it never dirties a commit). The deployed copies are the practical source of truth for front-end work: real, current, and full of the awkward shapes fixtures tend to miss. Regenerating them locally needs a token and about an hour.
- **`scripts/verify_render.mjs`** — evaluates `public/main.js` in a stubbed DOM, with `fetch` served from local files and `ApexCharts` recorded rather than drawn, then reports what each chart and section actually received. Exits non-zero when anything throws, so it can gate a commit or a deploy. Supports `--dump '<selector>'` to inspect one element's HTML and `--json` to assert on the report.
- **`SKILL.md`** — leads with *why* the check exists rather than just the commands, then the three steps: get real data → run headless → serve for a human look.

## Validation

Checked that it actually catches the failure it exists for. Run against the code that shipped the blank page (`8ad3246`, pre-#22):

```
FAIL — main.js threw
  error: TypeError: Cannot read properties of undefined (reading 'map')
    at mapToChartData (main.js:133:20)
    at renderStarsChart (main.js:306:28)
```

Same stack and the same line numbers the browser reported, exit code 1. Exit 0 on the fixed version, and 0 against current `main` with freshly downloaded data (12 charts, 22 star series, 7 sections with content). Every command in SKILL.md was run as written from a clean state.

## Scope and honesty about limits

SKILL.md is explicit that the stub proves the code *runs* and what data reached each element — never that the result *looks right*. Layout, contrast, overflow, dark mode and ApexCharts' own behaviour still need a browser, so the skill also covers serving `public/` over HTTP for a human to look at, and notes that `file://` cannot work because the page fetches JSON by relative path. It tells the reader to report those two things separately rather than saying "verified".

It also warns that deployed data only exercises fields that already exist, so a change that adds one should also be run against a copy of the data carrying the new shape — otherwise the new code path never executes and a PASS means very little.